### PR TITLE
Fix npm package name and structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenT2T
 Cross-platform core libraries for Open Translators to Things
 
+**[Refer to the wiki for documentation.](https://github.com/openT2T/opent2t/wiki)**
+
 ## Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,2 +1,8 @@
 build/
 node_modules/
+*.js
+*.js.map
+*.d.ts
+!typings/**/*.d.ts
+!test/*.js
+!tspublish.js

--- a/node/.npmignore
+++ b/node/.npmignore
@@ -1,0 +1,6 @@
+build/
+lib/
+test/
+typings/
+t*.json
+tspublish.js

--- a/node/package.json
+++ b/node/package.json
@@ -1,13 +1,15 @@
 {
-  "name": "opent2t-lib",
+  "name": "opent2t",
   "version": "0.1.0",
   "description": "Open Translators to Things",
-  "main": "build/lib",
-  "typings": "build/lib",
+  "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "build": "tsc",
     "lint": "tslint --force lib/**/*.ts",
-    "test": "tsc && ava --verbose"
+    "test": "tsc && ava --verbose",
+    "prepublish": "tsc && node ./tspublish.js prepublish",
+    "postpublish": "node ./tspublish.js postpublish"
   },
   "repository": {
     "type": "git",
@@ -26,6 +28,7 @@
   },
   "devDependencies": {
     "ava": "^0.15.2",
+    "shelljs": "^0.7.3",
     "tslint": "^3.14.0-dev.0",
     "typescript": "^2.0.0"
   },

--- a/node/tspublish.js
+++ b/node/tspublish.js
@@ -1,0 +1,27 @@
+// During development, TypeScript source code is in a separate /lib directory,
+// while compiled JavaScript output goes to /build/lib. But when creating an npm
+// package, all the JavaScript files (and type definitions) need to be relative
+// to the package root to enable direct module references. This script copies
+// the built files to the root before publishing, then cleans them up afterward.
+
+var fs = require("fs");
+var shell = require("shelljs");
+
+if (process.argv[2] === "prepublish") {
+    prepublish();
+} else if (process.argv[2] === "postpublish") {
+    postpublish();
+}
+
+function prepublish() {
+    if (fs.existsSync("build/lib")) {
+        shell.cp("-R", "build/lib/*", ".");
+    }
+}
+
+function postpublish() {
+    shell.find("-R", "build/lib/*").forEach(function(file) {
+        file = file.replace("build/lib/", "");
+        shell.rm("-rf", file);
+    });
+}


### PR DESCRIPTION
The purpose of these change is to get `npm publish` to pack up just the JavaScript code (with type-definitions and map files) relative to the package root. TypeScript code, test code, and other development-only files are excluded in `.npmignore`.
