### PR TITLE
Rename main OpenT2T class

### DIFF
--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,2 +1,8 @@
 build/
 node_modules/
+*.js
+*.js.map
+*.d.ts
+!typings/**/*.d.ts
+!test/*.js
+!tspublish.js

--- a/node/lib/OpenT2T.ts
+++ b/node/lib/OpenT2T.ts
@@ -1,13 +1,12 @@
 
-import { ThingSchema } from "./ThingSchema";
 import { IThingTranslator } from "./IThingTranslator";
-
+import { ThingSchema } from "./ThingSchema";
 import { EventEmitter } from "events";
 
 /**
  * Provides reflection-style access to thing properties and methods via translators.
  */
-export class ThingAccessor {
+export class OpenT2T {
     /**
      * Loads a schema from a module. This is just a convenience wrapper
      * around require(). Throws if the module could not be loaded.
@@ -115,15 +114,15 @@ export class ThingAccessor {
             translator: IThingTranslator,
             schemaName: string | ThingSchema,
             propertyName: string): Promise<any> {
-        let translatorForSchema = ThingAccessor.getTranslatorForSchema(translator, schemaName);
-        ThingAccessor.validateMemberName(propertyName);
+        let translatorForSchema = OpenT2T.getTranslatorForSchema(translator, schemaName);
+        OpenT2T.validateMemberName(propertyName);
 
-        let memberName = ThingAccessor.uncapitalize(propertyName);
+        let memberName = OpenT2T.uncapitalize(propertyName);
         let value: any = translatorForSchema[memberName];
         if (typeof value === "undefined") {
             // Allow (but do not require) the getProperty method to have an "Async" suffix
             // and/or return a Promise instead of an immediate value.
-            memberName = "get" + ThingAccessor.capitalize(propertyName);
+            memberName = "get" + OpenT2T.capitalize(propertyName);
             let getPropertyMethod: any = translatorForSchema[memberName];
             if (typeof getPropertyMethod === "function") {
                 // Invoke using call() to set `this` to translatorForSchema.
@@ -165,18 +164,18 @@ export class ThingAccessor {
             schemaName: string | ThingSchema,
             propertyName: string,
             value: any): Promise<void> {
-        let translatorForSchema = ThingAccessor.getTranslatorForSchema(translator, schemaName);
-        ThingAccessor.validateMemberName(propertyName);
+        let translatorForSchema = OpenT2T.getTranslatorForSchema(translator, schemaName);
+        OpenT2T.validateMemberName(propertyName);
 
         let setPropertyMethod: any;
-        let memberName = ThingAccessor.uncapitalize(propertyName);
+        let memberName = OpenT2T.uncapitalize(propertyName);
         let currentValue = translatorForSchema[memberName];
         if (typeof currentValue !== "undefined") {
             setPropertyMethod = function (newValue: any) { this[memberName] = newValue; };
         } else {
             // Allow (but do not require) the setProperty method to have an "Async" suffix
             // and/or return a Promise.
-            memberName = "set" + ThingAccessor.capitalize(propertyName);
+            memberName = "set" + OpenT2T.capitalize(propertyName);
             setPropertyMethod = translatorForSchema[memberName];
             if (typeof setPropertyMethod !== "function") {
                 memberName = memberName + "Async";
@@ -214,8 +213,8 @@ export class ThingAccessor {
             schemaName: string | ThingSchema,
             propertyName: string,
             callback: (value: any) => void): void {
-        let translatorForSchema = ThingAccessor.getTranslatorForSchema(translator, schemaName);
-        ThingAccessor.validateMemberName(propertyName);
+        let translatorForSchema = OpenT2T.getTranslatorForSchema(translator, schemaName);
+        OpenT2T.validateMemberName(propertyName);
 
         // The "on" method is defined by the Node.js EventEmitter class,
         // which device classes inherit from if they implement notifications.
@@ -245,8 +244,8 @@ export class ThingAccessor {
             schemaName: string | ThingSchema,
             propertyName: string,
             callback: (value: any) => void): void {
-        let translatorForSchema = ThingAccessor.getTranslatorForSchema(translator, schemaName);
-        ThingAccessor.validateMemberName(propertyName);
+        let translatorForSchema = OpenT2T.getTranslatorForSchema(translator, schemaName);
+        OpenT2T.validateMemberName(propertyName);
 
         // The "removeListener" method is defined by the Node.js EventEmitter class,
         // which device classes inherit from if they implement notifications.
@@ -280,8 +279,8 @@ export class ThingAccessor {
             schemaName: string | ThingSchema,
             methodName: string,
             args: any[]): Promise<any> {
-        let translatorForSchema = ThingAccessor.getTranslatorForSchema(translator, schemaName);
-        ThingAccessor.validateMemberName(methodName);
+        let translatorForSchema = OpenT2T.getTranslatorForSchema(translator, schemaName);
+        OpenT2T.validateMemberName(methodName);
         if (!Array.isArray(args)) {
             throw new TypeError("Args argument must be an array.");
         }

--- a/node/lib/index.ts
+++ b/node/lib/index.ts
@@ -1,10 +1,14 @@
 
-export { ThingAccessor } from "./ThingAccessor";
+export { IThingTranslator } from "./IThingTranslator";
+
 export {
+    JsonSchema,
     ThingCharacteristic,
     ThingSchema,
     ThingMethod,
     ThingProperty,
-    JsonSchema,
 } from "./ThingSchema";
-export { IThingTranslator } from "./IThingTranslator";
+
+import { OpenT2T } from "./OpenT2T";
+export { OpenT2T };
+export default OpenT2T;

--- a/node/lib/package/InstalledPackageSource.ts
+++ b/node/lib/package/InstalledPackageSource.ts
@@ -1,7 +1,6 @@
 
-import { PackageInfo } from "./PackageInfo";
-import { PackageSource } from "./PackageSource";
 import { LocalPackageSource } from "./LocalPackageSource";
+import { PackageInfo } from "./PackageInfo";
 
 import * as fs from "mz/fs";
 import * as path from "path";

--- a/node/lib/package/LocalPackageSource.ts
+++ b/node/lib/package/LocalPackageSource.ts
@@ -7,6 +7,8 @@ import { Parser } from "xml2js";
 import * as fs from "mz/fs";
 import * as path from "path";
 
+const packagePrefix: string = "opent2t-";
+
 /**
  * Reads package metadata and loads package information from a local source directory.
  *
@@ -83,7 +85,7 @@ export class LocalPackageSource extends PackageSource {
      * @returns {string} Derived NPM package name.
      */
     private static derivePackageName(name: string, type: string): string {
-        return "opent2t-" + type + "-" + name.replace(/\./g, "-");
+        return packagePrefix + type + "-" + name.replace(/\./g, "-");
     }
 
     /**
@@ -155,13 +157,17 @@ export class LocalPackageSource extends PackageSource {
      * package, or null if the requested package is not found at the source
      */
     public async getPackageInfoAsync(name: string): Promise<PackageInfo | null> {
-        if (name.startsWith("opent2t-schema-")) {
+        const schemaPackagePrefix: string = packagePrefix + "schema-";
+        const translatorPackagePrefix: string = packagePrefix + "translator-";
+        const onboardingPackagePrefix: string = packagePrefix + "onboarding-";
+
+        if (name.startsWith(schemaPackagePrefix)) {
             let schemaName: string =
-                    name.substr("opent2t-schema-".length).replace(/-/g, ".");
+                    name.substr(schemaPackagePrefix.length).replace(/-/g, ".");
             return await this.loadSchemaPackageInfoAsync(schemaName);
-        } else if (name.startsWith("opent2t-translator-")) {
+        } else if (name.startsWith(translatorPackagePrefix)) {
             let translatorName: string =
-                    name.substr("opent2t-translator-".length).replace(/-/g, ".");
+                    name.substr(translatorPackagePrefix.length).replace(/-/g, ".");
             // Search for a directory with a subdirectory matching the translator name.
             // Unfortunately the parent directory (schema name) a translator is under might
             // not be known ahead of time, so this search is required.
@@ -176,9 +182,9 @@ export class LocalPackageSource extends PackageSource {
                 }
             }
             return null;
-        } else if (name.startsWith("opent2t-onboarding-")) {
+        } else if (name.startsWith(onboardingPackagePrefix)) {
             let onboardingName: string =
-                    name.substr("opent2t-onboarding-".length).replace(/-/g, ".");
+                    name.substr(onboardingPackagePrefix.length).replace(/-/g, ".");
             return await this.loadOnboardingPackageInfoAsync(onboardingName);
         } else {
             // TODO: Scan all package.json files to find one with matching package name??

--- a/node/lib/package/LocalPackageSource.ts
+++ b/node/lib/package/LocalPackageSource.ts
@@ -258,7 +258,7 @@ export class LocalPackageSource extends PackageSource {
         let schemaInfos: any[] = [];
         let schemaModulePaths: string[] = [];
         if (Array.isArray(manifestXmlRoot.schemas) &&
-                manifestXmlRoot.schemas.length == 1 &&
+                manifestXmlRoot.schemas.length === 1 &&
                 Array.isArray(manifestXmlRoot.schemas[0].schema)) {
             let schemaElements = manifestXmlRoot.schemas[0].schema;
 
@@ -278,7 +278,7 @@ export class LocalPackageSource extends PackageSource {
                     let schemaModulePath: string = schemaId + "/" + schemaId;
                     schemaModulePaths.push(packageJson.name + "/" + schemaModulePath);
                     schemaInfos.push({
-                        moduleName: schemaModulePath
+                        moduleName: schemaModulePath,
                     });
                 }
             });
@@ -288,7 +288,7 @@ export class LocalPackageSource extends PackageSource {
         let onboardingModulePath: string = "";
         let onboardingProperties: any = {};
         if (Array.isArray(manifestXmlRoot.onboarding) &&
-                manifestXmlRoot.onboarding.length == 1) {
+                manifestXmlRoot.onboarding.length === 1) {
             let onboardingElement = manifestXmlRoot.onboarding[0];
             let onboardingId = onboardingElement.$.id;
             if (onboardingId) {
@@ -315,9 +315,9 @@ export class LocalPackageSource extends PackageSource {
             schemas: schemaInfos,
             translators: [{
                 moduleName: translatorModulePath,
-                schemas: schemaModulePaths,
                 onboarding: onboardingModulePath,
                 onboardingProperties: onboardingProperties,
+                schemas: schemaModulePaths,
             }],
             version: packageJson.version,
         };

--- a/node/lib/package/PackageInfo.ts
+++ b/node/lib/package/PackageInfo.ts
@@ -77,18 +77,18 @@ export class PackageInfo {
 
                 translators.push({
                     description: translatorsJson[moduleName].description,
-                    schemas: schemaReferences,
                     moduleName: moduleName,
                     onboarding: onboardingReference,
                     onboardingProperties: onboardingProperties,
+                    schemas: schemaReferences,
                 });
             });
         }
 
         return {
             description: packageJson.description,
-            schemas: schemas,
             name: packageJson.name,
+            schemas: schemas,
             translators: translators,
             version: packageJson.version,
         };

--- a/node/lib/schema/AllJoynSchemaReader.ts
+++ b/node/lib/schema/AllJoynSchemaReader.ts
@@ -1,10 +1,10 @@
 
 import {
-    ThingSchema,
+    JsonSchema,
     ThingMethod,
     ThingParameter,
     ThingProperty,
-    JsonSchema,
+    ThingSchema,
 } from "../ThingSchema";
 import { Parser } from "xml2js";
 
@@ -185,9 +185,9 @@ class AllJoynSchemaReader {
             canRead: (propertyAccess === "read" || propertyAccess === "readwrite"),
             canWrite: (propertyAccess === "write" || propertyAccess === "readwrite"),
             description: AllJoynSchemaReader.getOptionalElement(propertyElement, "description"),
-            schemaName: schemaName,
             name: propertyName,
             propertyType: AllJoynSchemaReader.allJoynTypeToJsonSchema(propertyType),
+            schemaName: schemaName,
         };
     }
 
@@ -226,9 +226,9 @@ class AllJoynSchemaReader {
             canRead: false,
             canWrite: false,
             description: AllJoynSchemaReader.getOptionalElement(signalElement, "description"),
-            schemaName: schemaName,
             name: signalName,
             propertyType: signalType,
+            schemaName: schemaName,
         };
     }
 
@@ -257,9 +257,9 @@ class AllJoynSchemaReader {
 
         return {
             description: AllJoynSchemaReader.getOptionalElement(methodElement, "description"),
-            schemaName: schemaName,
             name: methodName,
             parameters: parameters,
+            schemaName: schemaName,
         };
     }
 
@@ -277,9 +277,9 @@ class AllJoynSchemaReader {
                 canRead: matchingProperty.canRead || property.canRead,
                 canWrite: matchingProperty.canWrite || property.canWrite,
                 description: matchingProperty.description || property.description,
-                schemaName: matchingProperty.schemaName,
                 name: matchingProperty.name,
                 propertyType: matchingProperty.propertyType,
+                schemaName: matchingProperty.schemaName,
             });
         } else {
             properties.push(property);

--- a/node/lib/schema/AllJoynSchemaWriter.ts
+++ b/node/lib/schema/AllJoynSchemaWriter.ts
@@ -1,10 +1,10 @@
 
 import {
-    ThingSchema,
+    JsonSchema,
     ThingMethod,
     ThingParameter,
     ThingProperty,
-    JsonSchema,
+    ThingSchema,
 } from "../ThingSchema";
 import { Builder } from "xml2js";
 

--- a/node/lib/schema/OcfSchemaReader.ts
+++ b/node/lib/schema/OcfSchemaReader.ts
@@ -1,10 +1,10 @@
 
 import {
-    ThingSchema,
+    JsonSchema,     // tslint:disable-line:no-unused-variable
     ThingMethod,    // tslint:disable-line:no-unused-variable
     ThingParameter, // tslint:disable-line:no-unused-variable
     ThingProperty,  // tslint:disable-line:no-unused-variable
-    JsonSchema,     // tslint:disable-line:no-unused-variable
+    ThingSchema,
 } from "../ThingSchema";
 
 import * as fs from "mz/fs";

--- a/node/lib/schema/OcfSchemaWriter.ts
+++ b/node/lib/schema/OcfSchemaWriter.ts
@@ -1,10 +1,10 @@
 
 import {
-    ThingSchema,
+    JsonSchema,     // tslint:disable-line:no-unused-variable
     ThingMethod,    // tslint:disable-line:no-unused-variable
     ThingParameter, // tslint:disable-line:no-unused-variable
     ThingProperty,  // tslint:disable-line:no-unused-variable
-    JsonSchema,     // tslint:disable-line:no-unused-variable
+    ThingSchema,
 } from "../ThingSchema";
 
 import * as fs from "mz/fs";

--- a/node/lib/schema/TypeScriptSchemaWriter.ts
+++ b/node/lib/schema/TypeScriptSchemaWriter.ts
@@ -1,11 +1,11 @@
 
 import {
+    JsonSchema,
     ThingCharacteristic,
     ThingMethod,
     ThingParameter,
     ThingProperty,
     ThingSchema,
-    JsonSchema,
 } from "../ThingSchema";
 
 import * as fs from "mz/fs";

--- a/node/package.json
+++ b/node/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "typings": "index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "lint": "tslint --force lib/**/*.ts",
-    "test": "tsc && ava --verbose",
-    "prepublish": "tsc && node ./tspublish.js prepublish",
+    "build": "git clean -dfqx build/* && tsc",
+    "lint": "git clean -dfqx build/* && tsc && tslint --force lib/**/*.ts",
+    "test": "git clean -dfqx build/* && tsc && ava --verbose",
+    "prepublish": "git clean -dfqx build/* && tsc && node ./tspublish.js prepublish",
     "postpublish": "node ./tspublish.js postpublish"
   },
   "repository": {

--- a/node/test/OpenT2TTests.ts
+++ b/node/test/OpenT2TTests.ts
@@ -1,4 +1,4 @@
-// Tests for the ThingAccessor class
+// Tests for the OpenT2T class
 // using AVA test runner from https://github.com/avajs/ava
 
 import * as path from "path";
@@ -6,7 +6,7 @@ import test from "ava";
 import { TestContext } from "ava";
 
 import {
-    ThingAccessor,
+    OpenT2T,
     ThingSchema,
     IThingTranslator,
 } from "../lib";
@@ -22,7 +22,7 @@ function testPath(modulePath: string): any {
 }
 
 test("Load schema A", async t => {
-    let thingSchemaA: ThingSchema = await ThingAccessor.getSchemaAsync(
+    let thingSchemaA: ThingSchema = await OpenT2T.getSchemaAsync(
             testPath("./" + schemaA + "/" + schemaA));
     t.is(typeof thingSchemaA, "object") && t.truthy(thingSchemaA);
     t.is(thingSchemaA.name, schemaA);
@@ -33,7 +33,7 @@ test("Load schema A", async t => {
 });
 
 test("Load schema B", async t => {
-    let thingSchemaB: ThingSchema = await ThingAccessor.getSchemaAsync(
+    let thingSchemaB: ThingSchema = await OpenT2T.getSchemaAsync(
             testPath("./" + schemaB + "/" + schemaB));
     t.is(typeof thingSchemaB, "object") && t.truthy(thingSchemaB);
     t.is(thingSchemaB.name, schemaB);
@@ -44,59 +44,59 @@ test("Load schema B", async t => {
 });
 
 test("Thing One property get", async t => {
-    let thingOne: IThingTranslator = await ThingAccessor.createTranslatorAsync(
+    let thingOne: IThingTranslator = await OpenT2T.createTranslatorAsync(
             testPath("./" + schemaA + "/" + translatorOne), {});
     t.is(typeof thingOne, "object") && t.truthy(thingOne);
-    let propA1Value = await ThingAccessor.getPropertyAsync(thingOne, schemaA, "propA1");
+    let propA1Value = await OpenT2T.getPropertyAsync(thingOne, schemaA, "propA1");
     t.is(propA1Value, 123);
 });
 
 test("Thing One property set", async t => {
-    let thingOne: IThingTranslator = await ThingAccessor.createTranslatorAsync(
+    let thingOne: IThingTranslator = await OpenT2T.createTranslatorAsync(
             testPath("./" + schemaA + "/" + translatorOne), {});
     t.is(typeof thingOne, "object") && t.truthy(thingOne);
-    await ThingAccessor.setPropertyAsync(thingOne, schemaA, "propA2", "test2");
-    let propA2Value = await ThingAccessor.getPropertyAsync(thingOne, schemaA, "propA2");
+    await OpenT2T.setPropertyAsync(thingOne, schemaA, "propA2", "test2");
+    let propA2Value = await OpenT2T.getPropertyAsync(thingOne, schemaA, "propA2");
     t.is(propA2Value, "test2");
 });
 
 test("Thing One method call + notification", async t => {
-    let thingOne: IThingTranslator = await ThingAccessor.createTranslatorAsync(
+    let thingOne: IThingTranslator = await OpenT2T.createTranslatorAsync(
             testPath("./" + schemaA + "/" + translatorOne), {});
     t.is(typeof thingOne, "object") && t.truthy(thingOne);
     let methodCalled: boolean = false;
-    ThingAccessor.addPropertyListener(thingOne, schemaA, "signalA", (message: string) => {
+    OpenT2T.addPropertyListener(thingOne, schemaA, "signalA", (message: string) => {
         methodCalled = true;
     });
-    await ThingAccessor.invokeMethodAsync(thingOne, schemaA, "methodA1", []);
+    await OpenT2T.invokeMethodAsync(thingOne, schemaA, "methodA1", []);
     t.true(methodCalled);
 });
 
 test("Thing Two property get (schema A)", async t => {
-    let thingTwo: IThingTranslator = await ThingAccessor.createTranslatorAsync(
+    let thingTwo: IThingTranslator = await OpenT2T.createTranslatorAsync(
             testPath("./" + schemaB + "/" + translatorTwo), {});
     t.is(typeof thingTwo, "object") && t.truthy(thingTwo);
-    let propA1Value = await ThingAccessor.getPropertyAsync(thingTwo, schemaA, "propA1");
+    let propA1Value = await OpenT2T.getPropertyAsync(thingTwo, schemaA, "propA1");
     t.is(propA1Value, 123);
 });
 
 test("Thing Two property get (schema B)", async t => {
-    let thingTwo: IThingTranslator = await ThingAccessor.createTranslatorAsync(
+    let thingTwo: IThingTranslator = await OpenT2T.createTranslatorAsync(
             testPath("./" + schemaB + "/" + translatorTwo), {});
     t.is(typeof thingTwo, "object") && t.truthy(thingTwo);
-    let propA1Value = await ThingAccessor.getPropertyAsync(thingTwo, schemaB, "propA1");
+    let propA1Value = await OpenT2T.getPropertyAsync(thingTwo, schemaB, "propA1");
     t.is(propA1Value, 999);
 });
 
 test("Thing Two method that throws + notification", async t => {
-    let thingTwo: IThingTranslator = await ThingAccessor.createTranslatorAsync(
+    let thingTwo: IThingTranslator = await OpenT2T.createTranslatorAsync(
             testPath("./" + schemaB + "/" + translatorTwo), {});
     t.is(typeof thingTwo, "object") && t.truthy(thingTwo);
     let methodCalled: boolean = false;
-    ThingAccessor.addPropertyListener(
+    OpenT2T.addPropertyListener(
             thingTwo, schemaB, "signalB", (message: string) => {
         methodCalled = true;
     });
-    t.throws(ThingAccessor.invokeMethodAsync(thingTwo, schemaB, "methodB1", []));
+    t.throws(OpenT2T.invokeMethodAsync(thingTwo, schemaB, "methodB1", []));
     t.true(methodCalled);
 });


### PR DESCRIPTION
Primarily fixing https://github.com/openT2T/opent2t/issues/19: rename ThingAccessor -> OpenT2T

Also cleaning up a few minor things:
- Restoring lines I mistakenly removed from .gitignore. They prevent files generated by the prepublish script from being tracked by git.
- Fixing npm scripts in package.json to ensure the build directory is clean before compiling. It prevents orphan .js files from being left behind in the bulid directory when the .ts files are renamed or deleted.
- Fixing a bunch of tslint errors, mostly about things not being sorted correctly after the previous renames. 
