### PR TITLE
OCF schema reader

### DIFF
--- a/node/.gitignore
+++ b/node/.gitignore
@@ -4,5 +4,5 @@ node_modules/
 *.js.map
 *.d.ts
 !typings/**/*.d.ts
-!test/*.js
+!test/**/*.js
 !tspublish.js

--- a/node/lib/JsonSchema.ts
+++ b/node/lib/JsonSchema.ts
@@ -1,0 +1,75 @@
+
+/**
+ * Describes the schema of JSON data.
+ * Reference http://json-schema.org/ and
+ * https://raw.githubusercontent.com/tdegrunt/jsonschema/master/lib/index.d.ts
+ */
+export interface JsonSchema {
+    id?: string;
+    $schema?: string;
+    title?: string;
+    description?: string;
+    multipleOf?: number;
+    maximum?: number;
+    exclusiveMaximum?: boolean;
+    minimum?: number;
+    exclusiveMinimum?: boolean;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    additionalItems?: boolean | JsonSchema;
+    items?: JsonSchema | JsonSchema[];
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    required?: string[];
+    additionalProperties?: boolean | JsonSchema;
+    definitions?: { [name: string]: JsonSchema };
+    properties?: { [name: string]: JsonSchema };
+    patternProperties?: { [name: string]: JsonSchema };
+    dependencies?: { [name: string]: JsonSchema | string[] };
+    "enum"?: any[];
+    type?: string | string[];
+    allOf?: JsonSchema[];
+    anyOf?: JsonSchema[];
+    oneOf?: JsonSchema[];
+    not?: JsonSchema;
+}
+
+/**
+ * Methods for working with JSON schemas.
+ *
+ * (This class is intentionally given the same name as the interface.)
+ */
+export class JsonSchema {
+    /**
+     * Synchronously resolves "$ref" includes in the JSON schema.
+     *
+     * @param {JsonSchema} jsonSchema  Schema with "$ref" includes.
+     * @param {(name: string) => string} resolver  A callback function that takes the name
+     *     of a JSON file and returns the contents of that file.
+     * @returns {JsonSchema>  Schema with references resolved.
+     */
+    public static resolveReferences(
+            jsonSchema: JsonSchema, fileResolver: (fileName: string) => string): JsonSchema {
+        // TODO: Resolve JSON schema references.
+        return jsonSchema;
+    }
+
+    /**
+     * Asynchronously resolves "$ref" includes in the JSON schema.
+     *
+     * @param {JsonSchema} jsonSchema  Schema with "$ref" includes.
+     * @param {(name: string) => Promise<string>} resolver  A callback function that takes
+     *     the name of a JSON file and asynchronously returns the contents of that file.
+     * @returns {Promise<JsonSchema>}  Schema with references resolved.
+     */
+    public static resolveReferencesAsync(
+            jsonSchema: JsonSchema,
+            fileResolver: (fileName: string) => Promise<string>): Promise<JsonSchema> {
+        // TODO: Resolve JSON schema references.
+        return Promise.resolve(jsonSchema);
+    }
+}

--- a/node/lib/ThingSchema.ts
+++ b/node/lib/ThingSchema.ts
@@ -1,4 +1,6 @@
 
+import { JsonSchema } from "./JsonSchema";
+
 /**
  * Base class for thing schemas, properties, methods, and parameters, which
  * all have a name and optional description.
@@ -152,43 +154,4 @@ export class ThingParameter extends ThingCharacteristic {
      * True if this is an out parameter (return value), false if in.
      */
     public readonly isOut: boolean;
-}
-
-/**
- * Describes the schema of JSON data.
- * Reference http://json-schema.org/ and
- * https://raw.githubusercontent.com/tdegrunt/jsonschema/master/lib/index.d.ts
- */
-export interface JsonSchema {
-    id?: string;
-    $schema?: string;
-    title?: string;
-    description?: string;
-    multipleOf?: number;
-    maximum?: number;
-    exclusiveMaximum?: boolean;
-    minimum?: number;
-    exclusiveMinimum?: boolean;
-    maxLength?: number;
-    minLength?: number;
-    pattern?: string;
-    additionalItems?: boolean | JsonSchema;
-    items?: JsonSchema | JsonSchema[];
-    maxItems?: number;
-    minItems?: number;
-    uniqueItems?: boolean;
-    maxProperties?: number;
-    minProperties?: number;
-    required?: string[];
-    additionalProperties?: boolean | JsonSchema;
-    definitions?: { [name: string]: JsonSchema };
-    properties?: { [name: string]: JsonSchema };
-    patternProperties?: { [name: string]: JsonSchema };
-    dependencies?: { [name: string]: JsonSchema | string[] };
-    "enum"?: any[];
-    type?: string | string[];
-    allOf?: JsonSchema[];
-    anyOf?: JsonSchema[];
-    oneOf?: JsonSchema[];
-    not?: JsonSchema;
 }

--- a/node/lib/index.ts
+++ b/node/lib/index.ts
@@ -1,8 +1,7 @@
 
 export { IThingTranslator } from "./IThingTranslator";
-
+export { JsonSchema } from "./JsonSchema";
 export {
-    JsonSchema,
     ThingCharacteristic,
     ThingSchema,
     ThingMethod,

--- a/node/lib/schema/AllJoynSchemaReader.ts
+++ b/node/lib/schema/AllJoynSchemaReader.ts
@@ -1,6 +1,6 @@
 
+import { JsonSchema } from "../JsonSchema";
 import {
-    JsonSchema,
     ThingMethod,
     ThingParameter,
     ThingProperty,
@@ -20,6 +20,7 @@ class AllJoynSchemaReader {
 
     /**
      * Reads thing schemas from an AllJoyn schema XML file synchronously.
+     * (A synchronous implementation allows a schema to be loaded via a require().)
      *
      * @param {string} filePath  Path to the source XML file
      * @returns {ThingSchema[]} One or more schemas parsed from the file

--- a/node/lib/schema/AllJoynSchemaWriter.ts
+++ b/node/lib/schema/AllJoynSchemaWriter.ts
@@ -1,6 +1,6 @@
 
+import { JsonSchema } from "../JsonSchema";
 import {
-    JsonSchema,
     ThingMethod,
     ThingParameter,
     ThingProperty,

--- a/node/lib/schema/OcfSchemaReader.ts
+++ b/node/lib/schema/OcfSchemaReader.ts
@@ -1,40 +1,380 @@
 
+import { JsonSchema } from "../JsonSchema";
 import {
-    JsonSchema,     // tslint:disable-line:no-unused-variable
-    ThingMethod,    // tslint:disable-line:no-unused-variable
-    ThingParameter, // tslint:disable-line:no-unused-variable
-    ThingProperty,  // tslint:disable-line:no-unused-variable
+    ThingMethod,
+    ThingParameter,
     ThingSchema,
 } from "../ThingSchema";
 
 import * as fs from "mz/fs";
+import * as path from "path";
+import * as raml from "raml-1-parser";
+
+export = OcfSchemaReader;
 
 /**
  * Reads thing schema specifications in OCF RAML+JSON format.
  */
-export class OcfSchemaReader {
+class OcfSchemaReader {
+    /**
+     * Reads a thing schema from an OCF RAML file and supporting JSON files synchronously.
+     * (A synchronous implementation allows a schema to be loaded via a require().)
+     *
+     * @param {string} filePath  Path to the source RAML file
+     * @returns {ThingSchema} Schema parsed from the RAML and JSON files
+     */
     public static readThingSchemaFromFiles(ramlFilePath: string): ThingSchema {
-        let raml = fs.readFileSync(ramlFilePath, "utf8");
+        let ramlSchema: (raml.api08.Api | raml.api10.Api) = raml.loadApiSync(ramlFilePath);
+        let thingSchema: ThingSchema = OcfSchemaReader.ramlToThingSchema(ramlSchema);
 
-        // TODO: Scan for `!include *.json` lines in the RAML, then load JSON files (sync).
-        // TODO: Scan for `$ref` objects in each JSON, then recursively load references (sync).
-        // (Both sync and async read implementations may be desirable in difference scenarios.)
+        let schemaResolver: (fileName: string) => string =
+            OcfSchemaReader.resolveJsonSchema.bind(null, path.dirname(ramlFilePath));
 
-        throw new Error("not implemented");
+        for (let methodIndex = 0; methodIndex < thingSchema.methods.length; methodIndex++) {
+            let method = thingSchema.methods[methodIndex];
+            for (let paramIndex = 0; paramIndex < method.parameters.length; paramIndex++) {
+                let parameter = method.parameters[paramIndex];
+                method.parameters[paramIndex] = {
+                    isOut: parameter.isOut,
+                    name: parameter.name,
+                    parameterType: JsonSchema.resolveReferences(
+                        parameter.parameterType, schemaResolver),
+                };
+            }
+        }
+
+        return thingSchema;
     }
 
+    /**
+     * Reads a thing schema from an OCF RAML file and supporting JSON files asynchronously.
+     *
+     * @param {string} filePath  Path to the source RAML file
+     * @returns {Promise<ThingSchema>} Schema parsed from the RAML and JSON files
+     */
     public static async readThingSchemaFromFilesAsync(
             ramlFilePath: string): Promise<ThingSchema> {
-        let raml = await fs.readFile(ramlFilePath, "utf8");
+        let ramlSchema: (raml.api08.Api | raml.api10.Api) = await raml.loadApi(ramlFilePath);
+        let thingSchema: ThingSchema = OcfSchemaReader.ramlToThingSchema(ramlSchema);
 
-        // TODO: Scan for `!include *.json` lines in the RAML, then load JSON files (async).
-        // TODO: Scan for `$ref` objects in each JSON, then recursively load references (async).
+        let schemaResolver: (fileName: string) => Promise<string> =
+            OcfSchemaReader.resolveJsonSchemaAsync.bind(null, path.dirname(ramlFilePath));
 
+        for (let methodIndex = 0; methodIndex < thingSchema.methods.length; methodIndex++) {
+            let method = thingSchema.methods[methodIndex];
+            for (let paramIndex = 0; paramIndex < method.parameters.length; paramIndex++) {
+                let parameter = method.parameters[paramIndex];
+                method.parameters[paramIndex] = {
+                    isOut: parameter.isOut,
+                    name: parameter.name,
+                    parameterType: await JsonSchema.resolveReferencesAsync(
+                        parameter.parameterType, schemaResolver),
+                };
+            }
+        }
+
+        return thingSchema;
+    }
+
+    /**
+     * Reads a thing schema from an OCF RAML string and supporting JSON schema strings.
+     *
+     * @param {string} raml  RAML contents
+     * @param {{[fileName: string]: string}} json  Map from JSON file names to JSON contents
+     * @returns {ThingSchema} Schema parsed from the RAML and JSON strings
+     */
+    public static readThingSchema(
+            raml: string, json: {[fileName: string]: string}): ThingSchema {
+        // TODO: Call raml.parseRAMLSync() and pass in a resolver for JSON includes.
         throw new Error("not implemented");
     }
 
-    public static readThingSchema(
-            raml: string, json: {[fileName: string]: string}): ThingSchema {
-        throw new Error("not implemented");
+    /**
+     * Convert a parsed RAML API to a thing schema.
+     *
+     * Note this code (mostly) supports RAML v0.8 and v1.0 APIs.
+     * (OCF currently uses 0.8, so RAML 1.0 support is untested at this point.)
+     */
+    private static ramlToThingSchema(
+            ramlSchema: (raml.api08.Api | raml.api10.Api)): ThingSchema {
+        let schemaName = ramlSchema.title();
+        let description: string | undefined;
+        let methods: ThingMethod[] = [];
+
+        let ramlResources: Array<raml.api08.Resource | raml.api10.Resource> =
+                ramlSchema.resources();
+        ramlResources.forEach(ramlResource => {
+            // Remove a leading slash from the resource relative URI.
+            // Replace any other slashes, dots, or dashes with underscores.
+            let resourceName: string = ramlResource.relativeUri().value()
+                    .replace(/^\//, "").replace(/[/.-]/g, "_");
+
+            let resourceDescription: string = OcfSchemaReader.markdownToString(
+                    ramlResource.description());
+
+            // RAML doesn't have a top-level description, so use the description
+            // of the first resource as the thing schema description.
+            if (resourceDescription && !description) {
+                description = resourceDescription;
+            }
+
+            let ramlResourceMethods: Array<raml.api08.Method | raml.api10.Method> =
+                    ramlResource.methods();
+            ramlResourceMethods.forEach(ramlResourceMethod => {
+                let verb: string = ramlResourceMethod.method();
+                let methodDescription: string = OcfSchemaReader.markdownToString(
+                        ramlResourceMethod.description());
+
+                // Derive a JavaScript method name from the verb and resource name (URI).
+                let methodName: string = verb + OcfSchemaReader.capitalize(resourceName);
+
+                // Parameters are fixed, depending on the verb.
+                // Get the parameter types (JSON schemas) that are specified in the RAML.
+                let methodParameters: ThingParameter[] = [];
+                if (verb === "get") {
+                    let responseSchema: JsonSchema =
+                            OcfSchemaReader.getResourceMethodResponseSchema(
+                                ramlSchema.schemas(), resourceName, ramlResourceMethod);
+                    methodParameters.push({
+                        isOut: true,
+                        name: "result",
+                        parameterType: responseSchema,
+                    });
+                } else if (verb === "post") {
+                    let requestSchema: JsonSchema =
+                            OcfSchemaReader.getResourceMethodRequestSchema(
+                                ramlSchema.schemas(), resourceName, ramlResourceMethod);
+                    methodParameters.push({
+                        isOut: false,
+                        name: "value",
+                        parameterType: requestSchema,
+                    });
+                    let responseSchema: JsonSchema =
+                            OcfSchemaReader.getResourceMethodResponseSchema(
+                                ramlSchema.schemas(), resourceName, ramlResourceMethod);
+                    methodParameters.push({
+                        isOut: true,
+                        name: "result",
+                        parameterType: responseSchema,
+                    });
+                } else {
+                    console.warn("Ignoring unsupported verb '" + verb + "' for resource '" +
+                            resourceName + "' in schema '" + schemaName + "'");
+                }
+
+                methods.push({
+                    description: methodDescription,
+                    name: methodName,
+                    parameters: methodParameters,
+                    schemaName: schemaName,
+                });
+            });
+        });
+
+        return {
+            description: description,
+            methods: methods,
+            name: schemaName,
+            properties: [],
+            references: [],
+        };
+    }
+
+    /**
+     * Get the JSON schema for a RAML resource method's request body.
+     */
+    private static getResourceMethodRequestSchema(
+            ramlSchemas: Array<raml.api08.GlobalSchema | raml.api10.TypeDeclaration>,
+            resourceName: string,
+            ramlResourceMethod: raml.api08.Method | raml.api10.Method): JsonSchema {
+        let requestBodies: Array<raml.api08.BodyLike | raml.api10.TypeDeclaration> =
+                ramlResourceMethod.body();
+        if (requestBodies.length !== 1) {
+            // TODO: Look for one body that has content-type application/json?
+            throw new Error(
+                    (requestBodies.length === 0 ?
+                        "No request body" : "Multiple request bodies") +
+                    " found for method '" + ramlResourceMethod.method() +
+                    "' on resource '" + resourceName + "'");
+        }
+
+        let bodySchema: raml.api08.SchemaString | string[] = requestBodies[0].schema();
+        let schemaName: string;
+        if (!bodySchema) {
+            throw new Error(
+                    "No request body schema found for method '" + ramlResourceMethod.method() +
+                    "' on resource '" + resourceName + "'");
+        } else if (Array.isArray(bodySchema)) {
+            if (bodySchema.length !== 1) {
+                throw new Error(
+                        (bodySchema.length === 0 ?
+                            "No request body schema" : "Multiple request body schemas") +
+                        " found for method '" + ramlResourceMethod.method() +
+                        "' on resource '" + resourceName + "'");
+            }
+
+            schemaName = bodySchema[0];
+        } else {
+            schemaName = bodySchema.value();
+        }
+
+        try {
+            return OcfSchemaReader.getJsonSchema(ramlSchemas, schemaName);
+        } catch (error) {
+            throw new Error(
+                    "Failed to get request body schema for method '" +
+                    ramlResourceMethod.method() + "' on resource '" + resourceName +
+                    "': " + error.message);
+        }
+    }
+
+    /**
+     * Get the JSON schema for a RAML resource method's response body.
+     * The RAML may define different schemas for different response status codes;
+     * for now we're only looking for a success (200) response code.
+     */
+    private static getResourceMethodResponseSchema(
+            ramlSchemas: Array<raml.api08.GlobalSchema | raml.api10.TypeDeclaration>,
+            resourceName: string,
+            ramlResourceMethod: raml.api08.Method | raml.api10.Method,
+            responseCode?: string): JsonSchema {
+        let matchCode: string = responseCode || "200";
+
+        let ramlResponses: Array<raml.api08.Response | raml.api10.Response> =
+                    ramlResourceMethod.responses();
+        let ramlResponse: raml.api08.Response | raml.api10.Response | undefined =
+                ramlResponses.find(r => r.code().value() === matchCode);
+
+        if (!ramlResponse) {
+            throw new Error("Response not found with code " + matchCode + " for method '" +
+                    ramlResourceMethod.method() + "' on resource '" + resourceName + "'");
+        }
+
+        let responseBodies: Array<raml.api08.BodyLike | raml.api10.TypeDeclaration> =
+                ramlResponse.body();
+        if (responseBodies.length !== 1) {
+            // TODO: Look for one body that has content-type application/json?
+            throw new Error(
+                    (responseBodies.length === 0 ?
+                        "No response body" : "Multiple response bodies") +
+                    " found for response code " + matchCode + " for method '" +
+                    ramlResourceMethod.method() + "' on resource '" + resourceName + "'");
+        }
+
+        let bodySchema: raml.api08.SchemaString | string[] = responseBodies[0].schema();
+        let schemaName: string;
+        if (!bodySchema) {
+            throw new Error(
+                    "No response body schema found for response code " + matchCode +
+                    " for method '" + ramlResourceMethod.method() + "' on resource '" +
+                    resourceName + "'");
+        } else if (Array.isArray(bodySchema)) {
+            if (bodySchema.length !== 1) {
+                throw new Error(
+                        (bodySchema.length === 0 ?
+                            "No response body schema" : "Multiple response body schemas") +
+                        " found for response code " + matchCode + " for method '" +
+                        ramlResourceMethod.method() + "' on resource '" + resourceName + "'");
+            }
+
+            schemaName = bodySchema[0];
+        } else {
+            schemaName = bodySchema.value();
+        }
+
+        try {
+            return OcfSchemaReader.getJsonSchema(ramlSchemas, schemaName);
+        } catch (error) {
+            throw new Error(
+                    "Failed to get response body schema for response code " + matchCode +
+                    " for method '" + ramlResourceMethod.method() + "' on resource '" +
+                    resourceName + "': " + error.message);
+        }
+    }
+
+    /**
+     * Given a schema name, look it up in the RAML's global schema declarations,
+     * and parse the string as JSON.
+     */
+    private static getJsonSchema(
+            ramlSchemas: Array<raml.api08.GlobalSchema | raml.api10.TypeDeclaration>,
+            schemaName: string): JsonSchema {
+        let ramlSchema: raml.api08.GlobalSchema | raml.api10.TypeDeclaration | undefined =
+            ramlSchemas.find(s => {
+                return ((<raml.api08.GlobalSchema> s).key &&
+                        (<raml.api08.GlobalSchema> s).key() === schemaName) ||
+                       ((<raml.api10.TypeDeclaration> s).name &&
+                        ((<raml.api10.TypeDeclaration> s).name()) === schemaName);
+            });
+        if (!ramlSchema) {
+            throw new Error("Schema declaration not found: '" + schemaName + "'");
+        }
+
+        // TODO: Support RAML 1.0 schema declarations.
+        let jsonSchemaString: string | null = ((<raml.api08.GlobalSchema> ramlSchema).value ?
+                (<raml.api08.GlobalSchema> ramlSchema).value().value() : null);
+        if (!jsonSchemaString) {
+            throw new Error("Schema not specified: '" + schemaName + "'");
+        }
+
+        let jsonSchema: JsonSchema;
+        try {
+            jsonSchema = JSON.parse(jsonSchemaString);
+        } catch (error) {
+            throw new Error("Failed to parse JSON schema '" + schemaName +
+                    "': " + error.message);
+        }
+
+        return jsonSchema;
+    }
+
+    private static markdownToString(markdownString: raml.api08.MarkdownString): string {
+        if (markdownString) {
+            return markdownString.value().trim();
+        } else {
+            return "";
+        }
+    }
+
+    private static capitalize(propertyName: string) {
+        if (propertyName.length > 1) {
+            return propertyName[0].toUpperCase() + propertyName.substr(1);
+        }
+
+        return propertyName;
+    }
+
+    /**
+     * Look for a JSON schema file in the current directory or in a sibling directory
+     * having the same base name as the file. Used with JsonSchema.resolveReferences().
+     */
+    private static resolveJsonSchema(
+            ramlDirectory: string, fileName: string): string {
+        let filePath: string = path.join(ramlDirectory, fileName);
+        if (!fs.existsSync(filePath)) {
+            filePath = path.join(
+                    ramlDirectory, "..", path.basename(fileName, ".json"), fileName);
+            if (!fs.existsSync(filePath)) {
+                throw new Error("JSON schema file not found: " + fileName);
+            }
+        }
+        return fs.readFileSync(filePath, "utf8");
+    }
+
+    /**
+     * Look for a JSON schema file in the current directory or in a sibling directory
+     * having the same base name as the file.Used with JsonSchema.resolveReferencesAsync().
+     */
+    private static async resolveJsonSchemaAsync(
+            ramlDirectory: string, fileName: string): Promise<string> {
+        let filePath: string = path.join(ramlDirectory, fileName);
+        if (!(await fs.exists(filePath))) {
+            filePath = path.join(
+                    ramlDirectory, "..", path.basename(fileName, ".json"), fileName);
+            if (!(await fs.exists(filePath))) {
+                throw new Error("JSON schema file not found: " + fileName);
+            }
+        }
+        return await fs.readFile(filePath, "utf8");
     }
 }

--- a/node/lib/schema/OcfSchemaWriter.ts
+++ b/node/lib/schema/OcfSchemaWriter.ts
@@ -1,22 +1,23 @@
 
+import { JsonSchema } from "../JsonSchema"; // tslint:disable-line:no-unused-variable
 import {
-    JsonSchema,     // tslint:disable-line:no-unused-variable
     ThingMethod,    // tslint:disable-line:no-unused-variable
     ThingParameter, // tslint:disable-line:no-unused-variable
-    ThingProperty,  // tslint:disable-line:no-unused-variable
     ThingSchema,
 } from "../ThingSchema";
 
 import * as fs from "mz/fs";
 
+export = OcfSchemaWriter;
+
 /**
- * Reads and writes device interface specifications in OCF RAML+JSON format.
+ * Writes thing schema specifications in OCF RAML+JSON format.
  */
-export class OcfConverter {
+class OcfSchemaWriter {
     public static async writeThingSchemaToFilesAsync(
             thingSchema: ThingSchema, ramlFilePath: string): Promise<void> {
         let ramlAndJson: { raml: string, json: {[fileName: string]: string}} =
-                await OcfConverter.writeThingSchema(thingSchema);
+                await OcfSchemaWriter.writeThingSchema(thingSchema);
         await fs.writeFile(ramlFilePath, ramlAndJson.raml, "utf8");
 
         // TODO: Write each of the JSON files to the same directory as the raml file.

--- a/node/lib/schema/TypeScriptSchemaWriter.ts
+++ b/node/lib/schema/TypeScriptSchemaWriter.ts
@@ -1,6 +1,6 @@
 
+import { JsonSchema } from "../JsonSchema";
 import {
-    JsonSchema,
     ThingCharacteristic,
     ThingMethod,
     ThingParameter,
@@ -10,12 +10,14 @@ import {
 
 import * as fs from "mz/fs";
 
+export = TypeScriptSchemaWriter;
+
 /**
  * Writes thing schema specifications in TypeScript type-definition format.
  * A translator written in TypeScript can use the generated interface definitions
  * to have the compiler enforce proper implementation of thing schemas.
  */
-export class TypeScriptSchemaWriter {
+class TypeScriptSchemaWriter {
 
     /**
      * Writes thing schemas to a TypeScript type-definition file.

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Open Translators to Things",
   "main": "index.js",
   "typings": "index.d.ts",
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/opent2t/opent2t#readme",
   "dependencies": {
     "mz": "^2.4.0",
+    "raml-1-parser": "^0.2.32",
     "xml2js": "^0.4.17"
   },
   "devDependencies": {

--- a/node/test/AllJoynSchemaTests.ts
+++ b/node/test/AllJoynSchemaTests.ts
@@ -1,4 +1,4 @@
-// Tests for the AllJoynConverter class
+// Tests for the AllJoynSchemaReader and AllJoynSchemaWriter classes
 // using AVA test runner from https://github.com/avajs/ava
 
 import * as path from "path";

--- a/node/test/OcfSchemaTests.ts
+++ b/node/test/OcfSchemaTests.ts
@@ -1,0 +1,51 @@
+// Tests for the OcfSchemaReader and OcfSchemaWriter classes
+// using AVA test runner from https://github.com/avajs/ava
+
+import * as path from "path";
+import test from "ava";
+import { TestContext } from "ava";
+
+import { ThingSchema, JsonSchema } from "../lib";
+import { OcfSchemaReader } from "../lib/schema";
+
+// Requires modules relative to the /test directory.
+function requireTest(modulePath: string): any {
+    return require(path.join(__dirname, "../../test", modulePath));
+}
+
+test("OCF schema -> ThingSchema: C", t => {
+    let thingSchema: ThingSchema = requireTest(
+            "./org.opent2t.test.schemas.c/org.opent2t.test.schemas.c");
+
+    t.is(typeof thingSchema, "object");
+    t.is(thingSchema.name, "org.opent2t.test.schemas.c");
+    t.truthy(thingSchema.description);
+    t.is(thingSchema.properties.length, 0);
+    t.is(thingSchema.methods.length, 2);
+
+    t.is(typeof thingSchema.methods[0], "object");
+    t.is(thingSchema.methods[0].name, "getThermostatResURI");
+
+    t.is(thingSchema.methods[0].parameters.length, 1);
+    t.is(typeof thingSchema.methods[0].parameters[0].parameterType, "object");
+    t.truthy(thingSchema.methods[0].parameters[0].parameterType);
+    t.is(thingSchema.methods[0].parameters[0].isOut, true);
+    t.is(thingSchema.methods[0].parameters[0].parameterType.id,
+            "http://schemas.opentranslatorstothings.org/org.opent2t.test.schemas.c#");
+
+    t.is(typeof thingSchema.methods[1], "object");
+    t.is(thingSchema.methods[1].name, "postThermostatResURI");
+    t.is(thingSchema.methods[1].parameters.length, 2);
+
+    t.is(thingSchema.methods[1].parameters[0].isOut, false);
+    t.is(typeof thingSchema.methods[1].parameters[0].parameterType, "object");
+    t.truthy(thingSchema.methods[1].parameters[0].parameterType);
+    t.is(thingSchema.methods[1].parameters[0].parameterType.id,
+            "http://schemas.opentranslatorstothings.org/org.opent2t.test.schemas.c#");
+
+    t.is(thingSchema.methods[1].parameters[1].isOut, true);
+    t.is(typeof thingSchema.methods[1].parameters[1].parameterType, "object");
+    t.truthy(thingSchema.methods[1].parameters[1].parameterType);
+    t.is(thingSchema.methods[1].parameters[0].parameterType.id,
+            "http://schemas.opentranslatorstothings.org/org.opent2t.test.schemas.c#");
+});

--- a/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.js
+++ b/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.js
@@ -1,0 +1,5 @@
+// In a non-test interface module, this path would be: "opent2t/schema/OcfSchemaReader"
+var OcfSchemaReader = require("../../build/lib/schema/OcfSchemaReader");
+var path = require("path");
+module.exports = OcfSchemaReader.readThingSchemaFromFiles(
+    path.join(__dirname, path.basename(__filename, ".js") + ".raml"));

--- a/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.json
+++ b/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.json
@@ -1,0 +1,35 @@
+{
+  "id": "http://schemas.opentranslatorstothings.org/org.opent2t.test.schemas.c#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "",
+  "title": "OpenT2T Thermostat",
+  "definitions": {
+    "org.opent2t.sample.thermostat.superpopular": {
+      "type": "object",
+      "properties": {
+        "ambientTemperature": {
+          "$ref": "oic.r.temperature.json#/definitions/oic.r.temperature",
+          "description": "ReadOnly, Current temperature measured by the thermostat."
+        },
+        "targetTemperature": {
+          "$ref": "oic.r.temperature.json#/definitions/oic.r.temperature",
+          "description": "Target temperature."
+        },
+        "targetTemperatureHigh": {
+          "$ref": "oic.r.temperature.json#/definitions/oic.r.temperature",
+          "description": "Maximum target temperature."
+        },
+        "targetTemperatureLow": {
+          "$ref": "oic.r.temperature.json#/definitions/oic.r.temperature",
+          "description": "Minimum target temperature."
+        }
+      }
+    }
+  },
+  "type": "object",
+  "allOf": [
+    { "$ref": "oic.core.json#/definitions/oic.core" },
+    { "$ref": "oic.baseResource.json#/definitions/oic.r.baseResource" },
+    { "$ref": "#/definitions/org.opent2t.sample.thermostat.superpopular" }
+  ]
+}

--- a/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.raml
+++ b/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.raml
@@ -1,0 +1,75 @@
+#%RAML 0.8
+title: org.opent2t.test.schemas.c
+version: v1.0
+
+schemas:
+  - Thermostat: !include org.opent2t.test.schemas.c.json
+
+traits:
+  - interface:
+      queryParameters:
+        if:
+          enum: ["oic.if.a"]
+
+/thermostatResURI:
+  description: |
+   This resource describes the properties associated with Thermostat.
+   The resource is a composite resource.
+  displayName: Thermostat
+  is: [ interface ]
+
+  get:
+    description: |
+        Retrieves the current resource representation
+    responses:
+      200:
+        body:
+          application/json:
+            schema: Thermostat
+            example: |
+              {
+                "rt": "org.opent2t.test.schemas.c",
+                "id": "unique_example_id",
+                "ambientTemperature": {
+                  "temperature": 66,
+                  "units": "F"
+                },
+                "targetTemperature": {
+                  "temperature": 66,
+                  "units": "F"
+                },
+                "targetTemperatureHigh": {
+                  "temperature": 68,
+                  "units": "F"
+                },
+                "targetTemperatureLow": {
+                  "temperature": 64,
+                  "units": "F"
+                }
+            }
+
+  post:
+    body:
+      application/json:
+        schema: Thermostat
+        example: |
+          {
+            "id": "unique_example_id",
+            "target_temperature": {
+              "temperature": 74,
+              "units": "F"
+            }
+          }
+    responses:
+      200:
+        body:
+          application/json:
+            schema: Thermostat
+            example: |
+                {
+                    "id": "unique_example_id",
+                    "target_temperature": {
+                        "temperature": 74,
+                        "units": "F"
+                    }
+                }


### PR DESCRIPTION
Code and tests for reading OCF RAML+JSON schemas.

Expansion of $ref includes in the JSON schema is stubbed but not yet implemented. (I just didn't have time to finish tonight.) Other than that I think it does everything we need for now.

This PR also includes commits from https://github.com/openT2T/opent2t/pull/21 since it is built on top of it. I don't know how to separate them, though if the other PR is merged first then I think those changes will disappear from here... maybe.
