### PR TITLE
Resolve $ref includes in OCF JSON schemas

### DIFF
--- a/node/lib/OpenT2T.ts
+++ b/node/lib/OpenT2T.ts
@@ -35,19 +35,18 @@ export class OpenT2T {
     /**
      * Loads a schema from a module. (Overloaded method implementation.)
      */
-    public static getSchemaAsync(): Promise<ThingSchema> {
+    public static async getSchemaAsync(): Promise<ThingSchema> {
         let schemaModuleName: string = (arguments.length > 1 ?
                 arguments[0] + "/" + arguments[1] : arguments[0]);
-        return new Promise<ThingSchema>((resolve, reject) => {
-            let thingSchema: ThingSchema;
-            try {
-                thingSchema = require(schemaModuleName);
-            } catch (err) {
-                reject(err);
-                return;
-            }
-            resolve(thingSchema);
-        });
+        let thingSchema: ThingSchema;
+        let schemaExport: any = require(schemaModuleName);
+        if (typeof schemaExport.then === "function") {
+            // The schema module may indicate asynchronous loading by exporting a promise.
+            thingSchema = await schemaExport;
+        } else {
+            thingSchema = schemaExport;
+        }
+        return thingSchema;
     }
 
     /**

--- a/node/lib/schema/AllJoynSchemaReader.ts
+++ b/node/lib/schema/AllJoynSchemaReader.ts
@@ -17,21 +17,8 @@ export = AllJoynSchemaReader;
  * Reference https://wiki.allseenalliance.org/irb/extended_introspection_xml
  */
 class AllJoynSchemaReader {
-
     /**
-     * Reads thing schemas from an AllJoyn schema XML file synchronously.
-     * (A synchronous implementation allows a schema to be loaded via a require().)
-     *
-     * @param {string} filePath  Path to the source XML file
-     * @returns {ThingSchema[]} One or more schemas parsed from the file
-     */
-    public static readThingSchemasFromFile(filePath: string): ThingSchema[] {
-        let allJoynXml = fs.readFileSync(filePath, "utf8");
-        return AllJoynSchemaReader.readThingSchemas(allJoynXml);
-    }
-
-    /**
-     * Reads thing schemas from an AllJoyn schema XML file asynchronously.
+     * Reads thing schemas from an AllJoyn schema XML file.
      *
      * @param {string} filePath  Path to the source XML file
      * @returns {Promise<ThingSchema[]>} One or more schemas parsed from the file

--- a/node/package.json
+++ b/node/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/opent2t/opent2t#readme",
   "dependencies": {
+    "json-schema-ref-parser": "^3.1.2",
     "mz": "^2.4.0",
     "raml-1-parser": "^0.2.32",
     "xml2js": "^0.4.17"

--- a/node/test/AllJoynSchemaTests.ts
+++ b/node/test/AllJoynSchemaTests.ts
@@ -139,8 +139,8 @@ test("AllJoyn type <-> JSON schema: a{s(i(ss))}", t => {
     });
 });
 
-test("AllJoyn schema <-> ThingSchema: A", t => {
-    let thingSchema: ThingSchema = requireTest(
+test("AllJoyn schema <-> ThingSchema: A", async t => {
+    let thingSchema: ThingSchema = await requireTest(
             "./org.opent2t.test.schemas.a/org.opent2t.test.schemas.a");
 
     t.is(typeof thingSchema, "object");

--- a/node/test/OcfSchemaTests.ts
+++ b/node/test/OcfSchemaTests.ts
@@ -13,8 +13,11 @@ function requireTest(modulePath: string): any {
     return require(path.join(__dirname, "../../test", modulePath));
 }
 
-test("OCF schema -> ThingSchema: C", t => {
-    let thingSchema: ThingSchema = requireTest(
+const schemaName = "org.opent2t.test.schemas.c";
+const schemaUri = "http://schemas.opentranslatorstothings.org/" + schemaName + "#";
+
+test("OCF schema -> ThingSchema: C", async t => {
+    let thingSchema: ThingSchema = await requireTest(
             "./org.opent2t.test.schemas.c/org.opent2t.test.schemas.c");
 
     t.is(typeof thingSchema, "object");
@@ -30,8 +33,7 @@ test("OCF schema -> ThingSchema: C", t => {
     t.is(typeof thingSchema.methods[0].parameters[0].parameterType, "object");
     t.truthy(thingSchema.methods[0].parameters[0].parameterType);
     t.is(thingSchema.methods[0].parameters[0].isOut, true);
-    t.is(thingSchema.methods[0].parameters[0].parameterType.id,
-            "http://schemas.opentranslatorstothings.org/org.opent2t.test.schemas.c#");
+    t.is(thingSchema.methods[0].parameters[0].parameterType.id, schemaUri);
 
     t.is(typeof thingSchema.methods[1], "object");
     t.is(thingSchema.methods[1].name, "postThermostatResURI");
@@ -40,12 +42,23 @@ test("OCF schema -> ThingSchema: C", t => {
     t.is(thingSchema.methods[1].parameters[0].isOut, false);
     t.is(typeof thingSchema.methods[1].parameters[0].parameterType, "object");
     t.truthy(thingSchema.methods[1].parameters[0].parameterType);
-    t.is(thingSchema.methods[1].parameters[0].parameterType.id,
-            "http://schemas.opentranslatorstothings.org/org.opent2t.test.schemas.c#");
+    t.is(thingSchema.methods[1].parameters[0].parameterType.id, schemaUri);
 
     t.is(thingSchema.methods[1].parameters[1].isOut, true);
     t.is(typeof thingSchema.methods[1].parameters[1].parameterType, "object");
     t.truthy(thingSchema.methods[1].parameters[1].parameterType);
-    t.is(thingSchema.methods[1].parameters[0].parameterType.id,
-            "http://schemas.opentranslatorstothings.org/org.opent2t.test.schemas.c#");
+    t.is(thingSchema.methods[1].parameters[1].parameterType.id, schemaUri);
+
+    // Check that referenced schemas were resolved.
+    // The temperature.type property comes from the referenced oic.r.temperature schema.
+    let valueSchema: any = thingSchema.methods[1].parameters[1].parameterType;
+    t.truthy(
+            valueSchema.definitions &&
+            valueSchema.definitions[schemaName] &&
+            valueSchema.definitions[schemaName].properties &&
+            valueSchema.definitions[schemaName].properties.ambientTemperature);
+    let ambientTemperature = valueSchema.definitions[schemaName].properties.ambientTemperature;
+    t.truthy(ambientTemperature.properties &&
+            ambientTemperature.properties.temperature &&
+            ambientTemperature.properties.temperature.type === "number");
 });

--- a/node/test/org.opent2t.test.schemas.a/org.opent2t.test.schemas.a.js
+++ b/node/test/org.opent2t.test.schemas.a/org.opent2t.test.schemas.a.js
@@ -1,5 +1,5 @@
 // In a non-test interface module, this path would be: "opent2t/schema/AllJoynSchemaReader"
 var AllJoynSchemaReader = require("../../build/lib/schema/AllJoynSchemaReader");
 var path = require("path");
-module.exports = AllJoynSchemaReader.readThingSchemasFromFile(
-    path.join(__dirname, path.basename(__filename, ".js") + ".xml"))[0];
+module.exports = AllJoynSchemaReader.readThingSchemasFromFileAsync(
+    path.join(__dirname, path.basename(__filename, ".js") + ".xml")).then(schemas => schemas[0]);

--- a/node/test/org.opent2t.test.schemas.b/org.opent2t.test.schemas.b.js
+++ b/node/test/org.opent2t.test.schemas.b/org.opent2t.test.schemas.b.js
@@ -1,5 +1,5 @@
 // In a non-test interface module, this path would be: "opent2t/schema/AllJoynSchemaReader"
 var AllJoynSchemaReader = require("../../build/lib/schema/AllJoynSchemaReader");
 var path = require("path");
-module.exports = AllJoynSchemaReader.readThingSchemasFromFile(
-    path.join(__dirname, path.basename(__filename, ".js") + ".xml"))[0];
+module.exports = AllJoynSchemaReader.readThingSchemasFromFileAsync(
+    path.join(__dirname, path.basename(__filename, ".js") + ".xml")).then(schemas => schemas[0]);

--- a/node/test/org.opent2t.test.schemas.c/oic.baseResource.json
+++ b/node/test/org.opent2t.test.schemas.c/oic.baseResource.json
@@ -1,0 +1,61 @@
+{
+    "id": "http://openinterconnect.org/iotdatamodels/schemas/oic.baseResource.json#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Copyright (c) 2016 Open Connectivity Foundation, Inc. All rights reserved.",
+    "title": "Base Resource",
+    "definitions": {
+        "oic.r.baseresource": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "object"
+                        }
+                    ],
+                    "description": "The value sensed or actuated by this Resource"
+                },
+                "range": {
+                    "type": "array",
+                    "description": "The valid range for the value Property",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "integer"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "oic.core.json#/definitions/oic.core"
+        },
+        {
+            "$ref": "#/definitions/oic.r.baseresource"
+        }
+    ]
+}

--- a/node/test/org.opent2t.test.schemas.c/oic.core.json
+++ b/node/test/org.opent2t.test.schemas.c/oic.core.json
@@ -1,0 +1,50 @@
+{
+    "id": "http://openinterconnect.org/iotdatamodels/schemas/oic.core.json#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Copyright (c) 2016 Open Connectivity Foundation, Inc. All rights reserved.",
+    "title": "Core",
+    "$ref": "#/definitions/oic.core",
+    "definitions": {
+        "oic.core": {
+            "type": "object",
+            "properties": {
+                "rt": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string",
+                            "maxLength": 64
+                        }
+                    ],
+                    "minItems": 1,
+                    "description": "ReadOnly, Resource Type"
+                },
+                "if": {
+                    "type": "array",
+                    "description": "ReadOnly, The interface set supported by this resource",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "oic.if.baseline",
+                            "oic.if.ll",
+                            "oic.if.b",
+                            "oic.if.lb",
+                            "oic.if.rw",
+                            "oic.if.r",
+                            "oic.if.a",
+                            "oic.if.s"
+                        ]
+                    }
+                },
+                "n": {
+                    "type": "string",
+                    "description": "ReadOnly, Friendly name of the resource"
+                },
+                "id": {
+                    "type": "string",
+                    "description": "ReadOnly, Instance ID of this specific resource"
+                }
+            }
+        }
+    }
+}

--- a/node/test/org.opent2t.test.schemas.c/oic.r.temperature.json
+++ b/node/test/org.opent2t.test.schemas.c/oic.r.temperature.json
@@ -1,0 +1,61 @@
+{
+    "id": "http://openinterconnect.org/iotdatamodels/schemas/oic.r.temperature.json#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Copyright (c) 2016 Open Connectivity Foundation, Inc. All rights reserved.",
+    "title": "Temperature",
+    "definitions": {
+        "oic.r.temperature": {
+            "type": "object",
+            "properties": {
+                "temperature": {
+                    "type": "number",
+                    "description": "Current temperature setting or measurement"
+                },
+                "units": {
+                    "oneOf": [
+                        {
+                            "enum": [
+                                "C",
+                                "F",
+                                "K"
+                            ],
+                            "description": "ReadOnly, Units for the temperature value"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "enum": [
+                                    "C",
+                                    "F",
+                                    "K"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "range": {
+                    "type": "array",
+                    "description": "ReadOnly, Array defining min,max values for this temperature on this device",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        }
+    },
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "oic.core.json#/definitions/oic.core"
+        },
+        {
+            "$ref": "oic.baseResource.json#/definitions/oic.r.baseresource"
+        },
+        {
+            "$ref": "#/definitions/oic.r.temperature"
+        }
+    ],
+    "required": [
+        "temperature"
+    ]
+}

--- a/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.js
+++ b/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.js
@@ -1,5 +1,5 @@
 // In a non-test interface module, this path would be: "opent2t/schema/OcfSchemaReader"
 var OcfSchemaReader = require("../../build/lib/schema/OcfSchemaReader");
 var path = require("path");
-module.exports = OcfSchemaReader.readThingSchemaFromFiles(
+module.exports = OcfSchemaReader.readThingSchemaFromFilesAsync(
     path.join(__dirname, path.basename(__filename, ".js") + ".raml"));

--- a/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.json
+++ b/node/test/org.opent2t.test.schemas.c/org.opent2t.test.schemas.c.json
@@ -4,7 +4,7 @@
   "description": "",
   "title": "OpenT2T Thermostat",
   "definitions": {
-    "org.opent2t.sample.thermostat.superpopular": {
+    "org.opent2t.test.schemas.c": {
       "type": "object",
       "properties": {
         "ambientTemperature": {
@@ -29,7 +29,7 @@
   "type": "object",
   "allOf": [
     { "$ref": "oic.core.json#/definitions/oic.core" },
-    { "$ref": "oic.baseResource.json#/definitions/oic.r.baseResource" },
-    { "$ref": "#/definitions/org.opent2t.sample.thermostat.superpopular" }
+    { "$ref": "oic.baseResource.json#/definitions/oic.r.baseresource" },
+    { "$ref": "#/definitions/org.opent2t.test.schemas.c" }
   ]
 }


### PR DESCRIPTION
I found a node package "json-schema-ref-parser" that does most of the hard work here. But, its API is async-only (which is reasonable, because it involves reading data from files and http). So I've just made all the schema readers async-only, which is probably better anyway because before I was trying to maintain dual sync and async APIs and that was a hassle. The only purpose of the sync APIs before was to allow a `require()` call for a schema module to load the schema synchronously.

Now the `require()` call for a schema module will have to return a promise, which is a little unusual but not unprecedented. Because of this, I'll submit a small update to the translators repo to for the schema modules' JS code. (Callers who use the OpenT2T library APIs for loading modules are unaffected because those APIs are already async.)
