### PR TITLE
Defining new OpenT2TError class in the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 *.log
+*.tgz

--- a/node/lib/JsonSchema.ts
+++ b/node/lib/JsonSchema.ts
@@ -67,17 +67,17 @@ export class JsonSchema {
                 // (The top schema is probably not in the CWD.)
                 let relativeUri: string = path.relative(process.cwd(), file.url);
                 return fileResolver(relativeUri);
-            }
+            },
         };
 
         let dereferencedSchema: JsonSchema = await $RefParser.dereference(jsonSchema, {
+            dereference: {
+                circular: "ignore",
+            },
             resolve: {
                 file: fileResolverAdapter,
                 http: false,
             },
-            dereference: {
-                circular: "ignore",
-            }
         });
         return dereferencedSchema;
     }

--- a/node/lib/OpenT2T.ts
+++ b/node/lib/OpenT2T.ts
@@ -2,6 +2,7 @@
 import { IThingTranslator } from "./IThingTranslator";
 import { ThingSchema } from "./ThingSchema";
 import { EventEmitter } from "events";
+import {OpenT2TError} from "./OpenT2TError";
 
 /**
  * Provides reflection-style access to thing properties and methods via translators.
@@ -305,7 +306,7 @@ export class OpenT2T {
             return result;
         }
     }
-
+    
     /**
      * Check for a `resolveSchema` method on the translator, and if found use it to request an object
      * that implements properties and methods for the requested schema.

--- a/node/lib/OpenT2T.ts
+++ b/node/lib/OpenT2T.ts
@@ -2,7 +2,6 @@
 import { IThingTranslator } from "./IThingTranslator";
 import { ThingSchema } from "./ThingSchema";
 import { EventEmitter } from "events";
-import {OpenT2TError} from "./OpenT2TError";
 
 /**
  * Provides reflection-style access to thing properties and methods via translators.
@@ -306,7 +305,7 @@ export class OpenT2T {
             return result;
         }
     }
-    
+
     /**
      * Check for a `resolveSchema` method on the translator, and if found use it to request an object
      * that implements properties and methods for the requested schema.

--- a/node/lib/OpenT2TConstants.ts
+++ b/node/lib/OpenT2TConstants.ts
@@ -13,6 +13,7 @@ export class OpenT2TConstants {
     public static NotImplemented: string = "Not Implemented";
     public static DeviceNotFound: string  = "Device not found";
     public static InvalidResourceId: string = "Invalid reourceId";
+    public static InvalidHubId: string = "Invalid hub id";
     public static ResourceNotFound: string = "Resource not found";
     public static HMacSignatureVerificationFailed: string = "Payload signature doesn't match";
     public static InvalidAuthInfoInput: string =

--- a/node/lib/OpenT2TConstants.ts
+++ b/node/lib/OpenT2TConstants.ts
@@ -1,0 +1,25 @@
+
+/**
+ * Custom Error class that extends built-in Error.
+ */
+export class OpenT2TConstants {
+    // Device Names
+    public static WinkHubName = "Wink Hub";
+
+    // Errors
+    public static InternalServerError: string =
+    "Unexpected error. Please retry the operation or contact OpenT2T support";
+
+    public static NotImplemented: string = "Not Implemented";
+    public static DeviceNotFound: string  = "Device not found";
+    public static InvalidResourceId: string = "Invalid reourceId";
+    public static ResourceNotFound: string = "Resource not found";
+    public static HMacSignatureVerificationFailed: string = "Payload signature doesn't match";
+    public static InvalidAuthInfoInput: string =
+    "Invalid authInfo object. Please provide the existing authInfo object";
+
+    public static AccessDenied: string = "Access denied";
+    public static UnknownHubSubscribeRequest: string = "Unknown subscription request";
+    public static MustSubscribeToDevice: string = "Must subscribe to a device";
+
+}

--- a/node/lib/OpenT2TError.ts
+++ b/node/lib/OpenT2TError.ts
@@ -1,3 +1,4 @@
+import { OpenT2TConstants } from "./OpenT2TConstants";
 
 /**
  * Custom Error class that extends built-in Error.
@@ -7,6 +8,10 @@ export class OpenT2TError extends Error {
     public innerError: Error;
 
     constructor(statusCode: number, message: string, innerError?: Error) {
+        if (!message) {
+            message = OpenT2TConstants.InternalServerError;
+        }
+
         super(message);
 
        // Set the prototype explicitly due to TS breaking change.
@@ -15,9 +20,10 @@ export class OpenT2TError extends Error {
        // /Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work)
 
         Object.setPrototypeOf(this, OpenT2TError.prototype);
+
         if (statusCode) {
-                this.statusCode = statusCode;
-            } else {
+            this.statusCode = statusCode;
+        } else {
                 // TODO: Have a better mapping here based perhaps on innerError type
                 this.statusCode = 500; // Default to 500 (InternalServerError)
             }

--- a/node/lib/OpenT2TError.ts
+++ b/node/lib/OpenT2TError.ts
@@ -1,0 +1,33 @@
+
+/**
+ * Custom Error class that extends built-in Error.
+ */
+export class OpenT2TError extends Error {
+    statusCode: number;
+    innerError: Error;
+ 
+    constructor(statusCode: number, message: string, innerError?:Error) {
+        super(message);
+
+       // Set the prototype explicitly due to TS breaking change.
+       // Based on 
+       // (https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work)
+        
+        Object.setPrototypeOf(this, OpenT2TError.prototype);
+
+        if (statusCode){
+            this.statusCode = statusCode;
+        }
+        else
+        {
+            // TODO: Have a better mapping here based perhaps on innerError type
+            this.statusCode = 500; // Default to 500 (InternalServerError)
+        }
+
+        if (innerError){
+            this.innerError = innerError;
+        }
+
+        this.name = "OpenT2TError";
+    }
+}

--- a/node/lib/OpenT2TError.ts
+++ b/node/lib/OpenT2TError.ts
@@ -34,4 +34,15 @@ export class OpenT2TError extends Error {
 
         this.name = "OpenT2TError";
     }
+
+    public toJSON(): OpenT2TError {
+    // copy all fields from `this` to an empty object and return in
+    return Object.assign({}, this, {
+      // convert fields that need converting
+      innerErrorMessage: this.innerError.message,
+      innerErrorName: this.innerError.name,
+      innerErrorStack: this.innerError.stack,
+      message: this.message,
+    });
+  }
 }

--- a/node/lib/OpenT2TError.ts
+++ b/node/lib/OpenT2TError.ts
@@ -3,28 +3,26 @@
  * Custom Error class that extends built-in Error.
  */
 export class OpenT2TError extends Error {
-    statusCode: number;
-    innerError: Error;
- 
-    constructor(statusCode: number, message: string, innerError?:Error) {
+    public statusCode: number;
+    public innerError: Error;
+
+    constructor(statusCode: number, message: string, innerError?: Error) {
         super(message);
 
        // Set the prototype explicitly due to TS breaking change.
        // Based on 
-       // (https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work)
-        
+       // (https://github.com/Microsoft/TypeScript-wiki/blob/master/
+       // /Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work)
+
         Object.setPrototypeOf(this, OpenT2TError.prototype);
+        if (statusCode) {
+                this.statusCode = statusCode;
+            } else {
+                // TODO: Have a better mapping here based perhaps on innerError type
+                this.statusCode = 500; // Default to 500 (InternalServerError)
+            }
 
-        if (statusCode){
-            this.statusCode = statusCode;
-        }
-        else
-        {
-            // TODO: Have a better mapping here based perhaps on innerError type
-            this.statusCode = 500; // Default to 500 (InternalServerError)
-        }
-
-        if (innerError){
+        if (innerError) {
             this.innerError = innerError;
         }
 

--- a/node/lib/index.ts
+++ b/node/lib/index.ts
@@ -8,6 +8,8 @@ export {
     ThingProperty,
 } from "./ThingSchema";
 
+export { OpenT2TError } from "./OpenT2TError";
+
 import { OpenT2T } from "./OpenT2T";
 export { OpenT2T };
 export default OpenT2T;

--- a/node/lib/index.ts
+++ b/node/lib/index.ts
@@ -9,7 +9,7 @@ export {
 } from "./ThingSchema";
 
 export { OpenT2TError } from "./OpenT2TError";
-
+export { OpenT2TConstants } from "./OpenT2TConstants";
 import { OpenT2T } from "./OpenT2T";
 export { OpenT2T };
 export default OpenT2T;

--- a/node/lib/package/LocalPackageSource.ts
+++ b/node/lib/package/LocalPackageSource.ts
@@ -329,12 +329,11 @@ export class LocalPackageSource extends PackageSource {
                                 let descriptionProperties: any = {};
                                 flowElement.description.forEach((descriptionElement: any) => {
                                     descriptionProperties[descriptionElement.$.language] = descriptionElement._;
-                                }); // <description>
-                                
-                                var toPush = {
+                                }); // <description>                              
+                                let toPush = {
                                     descriptions: descriptionProperties,
                                     name: flowElement.arg[0].$.name,
-                                    type: undefined
+                                    type: undefined,
                                 };
 
                                 if (!!flowElement.$ && !!flowElement.$.type) {
@@ -396,7 +395,7 @@ export class LocalPackageSource extends PackageSource {
         let schemaInfos: any[] = [];
         let schemaModulePaths: string[] = [];
         if (Array.isArray(manifestXmlRoot.schemas) &&
-                manifestXmlRoot.schemas.length == 1 &&
+                manifestXmlRoot.schemas.length === 1 &&
                 Array.isArray(manifestXmlRoot.schemas[0].schema)) {
             let schemaElements = manifestXmlRoot.schemas[0].schema;
            // TODO: Will onboarding schemas also have 'main' schema concept ?
@@ -409,7 +408,7 @@ export class LocalPackageSource extends PackageSource {
                     let schemaModulePath: string = packageJson.name + "/" + schemaId + "/" + schemaId;
                     schemaModulePaths.push(schemaModulePath);
                     schemaInfos.push({
-                        moduleName: schemaModulePath
+                        moduleName: schemaModulePath,
                     });
                 }
             });

--- a/node/lib/package/PackageInfo.ts
+++ b/node/lib/package/PackageInfo.ts
@@ -197,7 +197,6 @@ export class PackageTranslatorInfo {
      */
     public readonly onboardingProperties: { [propertyName: string]: string };
 
-
     /**
      * Onboarding information pertaining to the hub device, which will have the onboarding flow information. 
      * For example, an 'input' flow type for acquiring username/client_id/client_secret
@@ -206,8 +205,7 @@ export class PackageTranslatorInfo {
     public readonly onboardingFlow: OnboardingFlow[];
 }
 
-export class PackageOnboardingInfo
-{
+export class PackageOnboardingInfo {
     /**
      * Relative path and name of the onboarding module within the package. This is not a
      * fully-qualified name; a package name prefix is normally required to resolve the
@@ -222,8 +220,7 @@ export class PackageOnboardingInfo
     public readonly schemas: string[];
 }
 
-export class OnboardingFlow
-{
+export class OnboardingFlow {
     /**
      * Name of the onboarding flow method. Example: 'getUserInput'' to indicate input from the end-user.
      */
@@ -235,8 +232,7 @@ export class OnboardingFlow
     public readonly flow: OnboardingFlowElement[];
 }
 
-export class OnboardingFlowElement
-{
+export class OnboardingFlowElement {
     /**
      * Specifies type of the flow step (ex: input, password). Each type has specified meaning.
      * For example, 'password' type indicates the UI to hide the text, when the user types.  
@@ -253,4 +249,3 @@ export class OnboardingFlowElement
      */
     public readonly descriptions: { [locale: string]: string };
 }
-

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Open Translators to Things",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "Open Translators to Things",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/node/test/OpenT2TTests.ts
+++ b/node/test/OpenT2TTests.ts
@@ -104,9 +104,14 @@ test("Thing Two method that throws + notification", async t => {
 });
 
 test("JSON.stringify() on OpenT2TError object returns a valid JSON object", async t=> {
-    let error = new OpenT2TError(400, "My Custom Message", new Error("innerError"));
+    let customMessage = "My custom error message";
+    let innerErrorMessage = "My Inner Error is a TypeError";
+    let innerError = new TypeError(innerErrorMessage);
+    let error = new OpenT2TError(400, customMessage, innerError);
     let jsonObjectString = JSON.stringify(error);
     console.log(jsonObjectString);
-    t.true(jsonObjectString.search("message") >= 0, 
-    "Found inner property `message` in json representation of OpenT2TError object");
+    t.true(jsonObjectString.search(customMessage) >= 0);
+    t.true(jsonObjectString.search(innerErrorMessage) >= 0);
+    t.true(jsonObjectString.search("innerErrorStack") >= 0);
+    t.true(jsonObjectString.search(innerError.name) >= 0);
 });

--- a/node/test/OpenT2TTests.ts
+++ b/node/test/OpenT2TTests.ts
@@ -9,6 +9,8 @@ import {
     OpenT2T,
     ThingSchema,
     IThingTranslator,
+    OpenT2TConstants,
+    OpenT2TError
 } from "../lib";
 
 const schemaA = "org.opent2t.test.schemas.a";
@@ -99,4 +101,12 @@ test("Thing Two method that throws + notification", async t => {
     });
     t.throws(OpenT2T.invokeMethodAsync(thingTwo, schemaB, "methodB1", []));
     t.true(methodCalled);
+});
+
+test("JSON.stringify() on OpenT2TError object returns a valid JSON object", async t=> {
+    let error = new OpenT2TError(400, "My Custom Message", new Error("innerError"));
+    let jsonObjectString = JSON.stringify(error);
+    console.log(jsonObjectString);
+    t.true(jsonObjectString.search("message") >= 0, 
+    "Found inner property `message` in json representation of OpenT2TError object");
 });


### PR DESCRIPTION
- Simple class that extends built-in Error interface.
- Expected to be referenced in Translators + HubController + consumers of HubController