### PR TITLE
Adding custom transport to Logger library

### DIFF
--- a/node/lib/ILogger.ts
+++ b/node/lib/ILogger.ts
@@ -1,8 +1,11 @@
 export interface ILogger {
-    error(msg: string, logObject?: any): void;
-    warn(msg: string, logObject?: any): void;
-    info(msg: string, logObject?: any): void;
-    verbose(msg: string, logObject?: any): void;
-    debug(msg: string, logObject?: any): void;
+    // Example of loggingMetadata is correlationVector
+    error(msg: string, logObject?: any, loggingMetadata?: string): void; 
+    warn(msg: string, logObject?: any, loggingMetadata?: string): void;
+    info(msg: string, logObject?: any, loggingMetadata?: string): void;
+    verbose(msg: string, logObject?: any, loggingMetadata?: string): void;
+    debug(msg: string, logObject?: any, loggingMetadata?: string): void;
     getConfiguredTransports(): Array<any>;
+    addTransport(transportObject: any): void;
+    removeTransport(transportObject: any): void;
 }

--- a/node/lib/ILogger.ts
+++ b/node/lib/ILogger.ts
@@ -1,14 +1,10 @@
 export interface ILogger {
-    // Example of loggingMetadata is correlationVector
-    error(msg: string, logObject?: any, logMetadata?: string): void;
+    // Example of logMetadata is correlationVector
+    error(msg: string, logMetadata?: string, logObject?: any): void;
     warn(msg: string, logMetadata?: string, logObject?: any): void;
-/*    warn(msg: string, logObject?: any, logMetadata?: string): void;
-    warn(msg: string, logParams?: Map<any, string>): void;
-    warn(msg: string, logParams?: Array<any>): void;*/
-
-    info(msg: string, logObject?: any, logMetadata?: string): void;
-    verbose(msg: string, logObject?: any, logMetadata?: string): void;
-    debug(msg: string, logObject?: any, logMetadata?: string): void;
+    info(msg: string, logMetadata?: string, logObject?: any): void;
+    verbose(msg: string, logMetadata?: string, logObject?: any): void;
+    debug(msg: string, logMetadata?: string, logObject?: any): void;
     getConfiguredTransports(): Array<any>;
     addTransport(transportObject: any): void;
     removeTransport(transportObject: any): void;

--- a/node/lib/ILogger.ts
+++ b/node/lib/ILogger.ts
@@ -8,4 +8,6 @@ export interface ILogger {
     getConfiguredTransports(): Array<any>;
     addTransport(transportObject: any): void;
     removeTransport(transportObject: any): void;
+    getLogLevel(transportObject: any): any;
+    setLogLevel(transportObject: any, logLevel: string): void;
 }

--- a/node/lib/ILogger.ts
+++ b/node/lib/ILogger.ts
@@ -1,10 +1,14 @@
 export interface ILogger {
     // Example of loggingMetadata is correlationVector
-    error(msg: string, logObject?: any, loggingMetadata?: string): void; 
-    warn(msg: string, logObject?: any, loggingMetadata?: string): void;
-    info(msg: string, logObject?: any, loggingMetadata?: string): void;
-    verbose(msg: string, logObject?: any, loggingMetadata?: string): void;
-    debug(msg: string, logObject?: any, loggingMetadata?: string): void;
+    error(msg: string, logObject?: any, logMetadata?: string): void;
+    warn(msg: string, logMetadata?: string, logObject?: any): void;
+/*    warn(msg: string, logObject?: any, logMetadata?: string): void;
+    warn(msg: string, logParams?: Map<any, string>): void;
+    warn(msg: string, logParams?: Array<any>): void;*/
+
+    info(msg: string, logObject?: any, logMetadata?: string): void;
+    verbose(msg: string, logObject?: any, logMetadata?: string): void;
+    debug(msg: string, logObject?: any, logMetadata?: string): void;
     getConfiguredTransports(): Array<any>;
     addTransport(transportObject: any): void;
     removeTransport(transportObject: any): void;

--- a/node/lib/Logger.ts
+++ b/node/lib/Logger.ts
@@ -59,7 +59,22 @@ export class Logger implements ILogger {
     }
 
     public warn(msg: string, logObject?: any, loggingMetadata?: string): void {
-        this.logger.warn(msg, logObject, loggingMetadata);
+       if(typeof(logObject === 'undefined') && typeof(loggingMetadata) !== 'undefined')
+       {
+           this.logger.error(msg, loggingMetadata);
+       }
+       else if (typeof(logObject !== 'undefined') && typeof(loggingMetadata) !== 'undefined')
+       {
+           this.logger.error(msg, logObject);
+       }
+       else if (typeof(logObject === 'undefined') && typeof(loggingMetadata) === 'undefined')
+       {
+           this.logger.error(msg);
+       }        
+       else
+       { 
+           this.logger.warn(msg, logObject, loggingMetadata);
+       }
     }
 
     public info(msg: string, logObject?: any, loggingMetadata?: string): void {

--- a/node/lib/Logger.ts
+++ b/node/lib/Logger.ts
@@ -6,7 +6,6 @@ import * as winston from "winston";
 const timeStamp: string = "timestamp";
 
 export class Logger implements ILogger {
-
     private static flag: boolean = true;
     private globalLogLevel: string = "debug";
     private logger: LoggerInstance;
@@ -23,6 +22,10 @@ export class Logger implements ILogger {
         let consoleTransport = new winston.transports.Console({
             colorize: true,
             level: this.globalLogLevel,
+/*            prettyPrint: function ( object: any ){
+                return JSON.stringify(object);
+            },            
+            stringify: (obj: any) => JSON.stringify(obj),*/
         });
 
         this.logger.configure({
@@ -52,39 +55,43 @@ export class Logger implements ILogger {
         }
     }
 
-   public error(msg: string, logObject?: any, loggingMetadata?: string): void {
-        this.logger.error(msg, logObject, loggingMetadata);
+   public error(msg: string, logObject?: any, logMetadata?: string): void {
+        this.logger.error(msg, logObject, logMetadata);
     }
 
-    public warn(msg: string, logObject?: any, loggingMetadata?: string): void {
-       if(typeof(logObject === 'undefined') && typeof(loggingMetadata) !== 'undefined')
+/*    public warn(msg: string, logObject?: any, logMetadata?: string): void {
+       if(typeof(logObject === 'undefined') && typeof(logMetadata) !== 'undefined')
        {
-           this.logger.warn(msg, loggingMetadata);
+           this.logger.warn(msg, logMetadata);
        }
-       else if (typeof(logObject !== 'undefined') && typeof(loggingMetadata) !== 'undefined')
+       else if (typeof(logObject !== 'undefined') && typeof(logMetadata) !== 'undefined')
        {
            this.logger.warn(msg, logObject);
        }
-       else if (typeof(logObject === 'undefined') && typeof(loggingMetadata) === 'undefined')
+       else if (typeof(logObject === 'undefined') && typeof(logMetadata) === 'undefined')
        {
            this.logger.warn(msg);
        }        
        else
        { 
-           this.logger.warn(msg, logObject, loggingMetadata);
+           this.logger.warn(msg, logObject, logMetadata);
        }
+    }*/
+
+    public warn(msg: string, logMetadata?: string, logObject?: any): void {
+        this.logger.warn(msg, logMetadata, logObject);
     }
 
-    public info(msg: string, logObject?: any, loggingMetadata?: string): void {
-        this.logger.info(msg, logObject, loggingMetadata);
+    public info(msg: string, logObject?: any, logMetadata?: string): void {
+        this.logger.info(msg, logObject, logMetadata);
     }
 
-    public verbose(msg: string, logObject?: any, loggingMetadata?: string): void {
-        this.logger.verbose(msg, logObject, loggingMetadata);
+    public verbose(msg: string, logObject?: any, logMetadata?: string): void {
+        this.logger.verbose(msg, logObject, logMetadata);
     }
 
-    public debug(msg: string, logObject?: any, loggingMetadata?: string): void {
-        this.logger.debug(msg, logObject, loggingMetadata);
+    public debug(msg: string, logObject?: any, logMetadata?: string): void {
+        this.logger.debug(msg, logObject, logMetadata);
     }
 
     public getConfiguredTransports(): Array<any> {
@@ -100,9 +107,8 @@ export class Logger implements ILogger {
     public removeTransport(transportObject: any): void {
         this.logger.remove(transportObject);
 
-        var index = this.transportList.indexOf(transportObject);
-        if (index > -1)
-        {
+        let index = this.transportList.indexOf(transportObject);
+        if (index > -1) {
             this.transportList.splice(index, 1);
         }
     }

--- a/node/lib/Logger.ts
+++ b/node/lib/Logger.ts
@@ -85,8 +85,25 @@ export class Logger implements ILogger {
         this.logger.remove(transportObject);
 
         let index = this.transportList.indexOf(transportObject);
+
         if (index > -1) {
             this.transportList.splice(index, 1);
+        }
+    }
+
+    public getLogLevel(transportObject: any): any {
+        let index = this.transportList.indexOf(transportObject);
+
+        if (index > -1) {
+            return this.transportList[index].level;
+        }
+    }
+
+    public setLogLevel(transportObject: any, logLevel: string): void {
+        let index = this.transportList.indexOf(transportObject);
+
+        if (index > -1) {
+            this.transportList[index].level = logLevel;
         }
     }
 

--- a/node/lib/Logger.ts
+++ b/node/lib/Logger.ts
@@ -11,6 +11,8 @@ export class Logger implements ILogger {
     private globalLogLevel: string = "debug";
     private logger: LoggerInstance;
     private transportList: Array<any> = [];
+    private consoleTransport: any;
+    private fileTransport: any;
 
     constructor(logLevel?: string, filename?: string, logger?: LoggerInstance) {
         this.logger = logger || <any> winston;
@@ -20,21 +22,21 @@ export class Logger implements ILogger {
             this.globalLogLevel = logLevel;
         }
 
-        let consoleTransport = new winston.transports.Console({
+        this.consoleTransport = new winston.transports.Console({
             colorize: true,
             level: this.globalLogLevel,
         });
 
         this.logger.configure({
             transports: [
-                consoleTransport,
+                this.consoleTransport,
             ],
         });
 
-        this.transportList.push(consoleTransport);
+        this.transportList.push(this.consoleTransport);
 
-        if (Logger.flag === true && filename ) {
-            let fileTransport = new winston.transports.File({
+        if (Logger.flag === true && filename) {
+            this.fileTransport = new winston.transports.File({
                 filename: filename,
                 handleExceptions: true,
                 level: this.globalLogLevel,
@@ -42,38 +44,50 @@ export class Logger implements ILogger {
 
             this.logger.configure({
                 transports: [
-                    consoleTransport,
-                    fileTransport,
+                    this.consoleTransport,
+                    this.fileTransport,
                 ],
             });
 
-            this.transportList.push(fileTransport);
+            this.transportList.push(this.fileTransport);
             Logger.flag = false;
         }
     }
 
-   public error(msg: string, logObject?: any): void {
-        this.logger.error(msg, logObject);
+   public error(msg: string, logObject?: any, loggingMetadata?: string): void {
+        this.logger.error(msg, logObject, loggingMetadata);
     }
 
-    public warn(msg: string, logObject?: any): void {
-        this.logger.warn(msg, logObject);
+    public warn(msg: string, logObject?: any, loggingMetadata?: string): void {
+        this.logger.warn(msg, logObject, loggingMetadata);
     }
 
-    public info(msg: string, logObject?: any): void {
-        this.logger.info(msg, logObject);
+    public info(msg: string, logObject?: any, loggingMetadata?: string): void {
+        this.logger.info(msg, logObject, loggingMetadata);
     }
 
-    public verbose(msg: string, logObject?: any): void {
-        this.logger.verbose(msg, logObject);
+    public verbose(msg: string, logObject?: any, loggingMetadata?: string): void {
+        this.logger.verbose(msg, logObject, loggingMetadata);
     }
 
-    public debug(msg: string, logObject?: any): void {
-        this.logger.debug(msg, logObject);
+    public debug(msg: string, logObject?: any, loggingMetadata?: string): void {
+        this.logger.debug(msg, logObject, loggingMetadata);
     }
 
     public getConfiguredTransports(): Array<any> {
         return this.transportList;
+    }
+
+    public addTransport(transportObject: any): void {
+        this.logger.add(transportObject);
+
+        this.transportList.push(transportObject);
+    }
+
+    public removeTransport(transportObject: any): void {
+        this.logger.remove(transportObject);
+
+        this.transportList.pop();
     }
 
     public normalizeWith(normalizer: (logObject: any) => any): ILogger {

--- a/node/lib/Logger.ts
+++ b/node/lib/Logger.ts
@@ -22,10 +22,6 @@ export class Logger implements ILogger {
         let consoleTransport = new winston.transports.Console({
             colorize: true,
             level: this.globalLogLevel,
-/*            prettyPrint: function ( object: any ){
-                return JSON.stringify(object);
-            },            
-            stringify: (obj: any) => JSON.stringify(obj),*/
         });
 
         this.logger.configure({
@@ -55,43 +51,24 @@ export class Logger implements ILogger {
         }
     }
 
-   public error(msg: string, logObject?: any, logMetadata?: string): void {
-        this.logger.error(msg, logObject, logMetadata);
+   public error(msg: string, logMetadata?: string, logObject?: any): void {
+        this.logger.error(msg, logMetadata, logObject);
     }
-
-/*    public warn(msg: string, logObject?: any, logMetadata?: string): void {
-       if(typeof(logObject === 'undefined') && typeof(logMetadata) !== 'undefined')
-       {
-           this.logger.warn(msg, logMetadata);
-       }
-       else if (typeof(logObject !== 'undefined') && typeof(logMetadata) !== 'undefined')
-       {
-           this.logger.warn(msg, logObject);
-       }
-       else if (typeof(logObject === 'undefined') && typeof(logMetadata) === 'undefined')
-       {
-           this.logger.warn(msg);
-       }        
-       else
-       { 
-           this.logger.warn(msg, logObject, logMetadata);
-       }
-    }*/
 
     public warn(msg: string, logMetadata?: string, logObject?: any): void {
         this.logger.warn(msg, logMetadata, logObject);
     }
 
-    public info(msg: string, logObject?: any, logMetadata?: string): void {
-        this.logger.info(msg, logObject, logMetadata);
+    public info(msg: string, logMetadata?: string, logObject?: any): void {
+        this.logger.info(msg, logMetadata, logObject);
     }
 
-    public verbose(msg: string, logObject?: any, logMetadata?: string): void {
-        this.logger.verbose(msg, logObject, logMetadata);
+    public verbose(msg: string, logMetadata?: string, logObject?: any): void {
+        this.logger.verbose(msg, logMetadata, logObject);
     }
 
-    public debug(msg: string, logObject?: any, logMetadata?: string): void {
-        this.logger.debug(msg, logObject, logMetadata);
+    public debug(msg: string, logMetadata?: string, logObject?: any): void {
+        this.logger.debug(msg, logMetadata, logObject);
     }
 
     public getConfiguredTransports(): Array<any> {

--- a/node/lib/Logger.ts
+++ b/node/lib/Logger.ts
@@ -100,7 +100,11 @@ export class Logger implements ILogger {
     public removeTransport(transportObject: any): void {
         this.logger.remove(transportObject);
 
-        this.transportList.pop();
+        var index = this.transportList.indexOf(transportObject);
+        if (index > -1)
+        {
+            this.transportList.splice(index, 1);
+        }
     }
 
     public normalizeWith(normalizer: (logObject: any) => any): ILogger {

--- a/node/lib/Logger.ts
+++ b/node/lib/Logger.ts
@@ -11,8 +11,6 @@ export class Logger implements ILogger {
     private globalLogLevel: string = "debug";
     private logger: LoggerInstance;
     private transportList: Array<any> = [];
-    private consoleTransport: any;
-    private fileTransport: any;
 
     constructor(logLevel?: string, filename?: string, logger?: LoggerInstance) {
         this.logger = logger || <any> winston;
@@ -22,21 +20,21 @@ export class Logger implements ILogger {
             this.globalLogLevel = logLevel;
         }
 
-        this.consoleTransport = new winston.transports.Console({
+        let consoleTransport = new winston.transports.Console({
             colorize: true,
             level: this.globalLogLevel,
         });
 
         this.logger.configure({
             transports: [
-                this.consoleTransport,
+                consoleTransport,
             ],
         });
 
-        this.transportList.push(this.consoleTransport);
+        this.transportList.push(consoleTransport);
 
         if (Logger.flag === true && filename) {
-            this.fileTransport = new winston.transports.File({
+            let fileTransport = new winston.transports.File({
                 filename: filename,
                 handleExceptions: true,
                 level: this.globalLogLevel,
@@ -44,12 +42,12 @@ export class Logger implements ILogger {
 
             this.logger.configure({
                 transports: [
-                    this.consoleTransport,
-                    this.fileTransport,
+                    consoleTransport,
+                    fileTransport,
                 ],
             });
 
-            this.transportList.push(this.fileTransport);
+            this.transportList.push(fileTransport);
             Logger.flag = false;
         }
     }
@@ -61,15 +59,15 @@ export class Logger implements ILogger {
     public warn(msg: string, logObject?: any, loggingMetadata?: string): void {
        if(typeof(logObject === 'undefined') && typeof(loggingMetadata) !== 'undefined')
        {
-           this.logger.error(msg, loggingMetadata);
+           this.logger.warn(msg, loggingMetadata);
        }
        else if (typeof(logObject !== 'undefined') && typeof(loggingMetadata) !== 'undefined')
        {
-           this.logger.error(msg, logObject);
+           this.logger.warn(msg, logObject);
        }
        else if (typeof(logObject === 'undefined') && typeof(loggingMetadata) === 'undefined')
        {
-           this.logger.error(msg);
+           this.logger.warn(msg);
        }        
        else
        { 

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Open Translators to Things",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/node/test/OpenT2TTests.ts
+++ b/node/test/OpenT2TTests.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as fs from "mz/fs";
 import test from "ava";
 import { TestContext } from "ava";
+import * as winston from "winston";
 
 import {
     OpenT2T,
@@ -141,9 +142,25 @@ test("Logger with default parameters can be instantiated multiple times", async 
 });
 
 test("Logger can be instantiated with custom file parameter", async t => {
-    let logger = new Logger(undefined, testLogFileName) ;
+    let logger = new Logger(undefined, testLogFileName);
     logger.info("Writing default level to default console + file.");
     logger.warn("writing warn level to default console + file.");
+    t.is(logger.getConfiguredTransports().length, 2);
+});
+
+test("Logger with default parameters can log custom loggingMetadata parameter like a correlationVector", async t => {
+    let logger = new Logger();
+    logger.info("Writing default level to default console with loggingMetadata: ", undefined, "ABC123");
+    logger.warn("writing warn level to default console with loggingMetadata.", undefined, "XYZ456");
+});
+
+test("Logger with default parameters can add and remove transports", async t => {
+    let logger = new Logger();
+    logger.addTransport(winston.transports.Http);
+    t.is(logger.getConfiguredTransports().length, 2);
+    logger.removeTransport(winston.transports.Http);
+    t.is(logger.getConfiguredTransports().length, 1);
+    logger.addTransport(winston.transports.Http);
     t.is(logger.getConfiguredTransports().length, 2);
 });
 

--- a/node/test/OpenT2TTests.ts
+++ b/node/test/OpenT2TTests.ts
@@ -167,6 +167,14 @@ test("Logger with default parameters can add and remove transports", async t => 
     t.is(logger.getConfiguredTransports().length, 2);
 });
 
+test("Getter/Setter for a transport logLevel", async t => {
+    let logger = new Logger();
+    let transportList: Array<any> = logger.getConfiguredTransports();
+    t.is(logger.getLogLevel(transportList[0]), 'debug'); // default log level
+    logger.setLogLevel(transportList[0], 'info');
+    t.is(logger.getLogLevel(transportList[0]), 'info');
+});
+
 test.after("Deleting created log file", async t => {
     let fullPathName = path.join(__dirname, testLogFileName);
     return fs.unlinkSync(fullPathName);

--- a/node/test/OpenT2TTests.ts
+++ b/node/test/OpenT2TTests.ts
@@ -130,7 +130,7 @@ test("Logger with default parameters can log a non-primitive type", async t => {
     let myArray: Array<any> = ["firstObject", "secondObject", ["nestedObj1", "nestedObj2"]];
     logger.info("Writing default level to default console.");
     logger.debug("writing debug level to default console.");
-    logger.error("Writing array object to default console", myArray);
+    logger.warn("Writing array object to default console", undefined, myArray);
 });
 
 test("Logger with default parameters can be instantiated multiple times", async t => {
@@ -151,24 +151,10 @@ test("Logger can be instantiated with custom file parameter", async t => {
 test("Logger can log custom logMetadata, e.g. correlationVector", async t => {
     let logger = new Logger();
     let stringObject = "Random String"
-    logger.info("Logging at default level with logMetadata:", stringObject, "ABC123");
-
-    // Swapping order of logObject and logMetadata since the latter will be used more often
-    // Pro: Simple usage
-    logger.warn("Logging at  warn level with logMetadata & logObject:", "ABC123", stringObject);
-    logger.warn("Logging at  warn level without logObject:", "ABC123");
-
-    // Map: Usage gets complicated
-/*    var temp = new Map<any, string>();
-    temp.set('logObject', stringObject);
-    temp.set('logMetadata', "ABC123");
-    logger.warn("writing warn level:", temp);*/
-    
-    // Associative Array: Usage still complicated, and winston doesn't log the Array contents, though console.log does
-/*    var temp:any = new Array();
-    temp["logObject"] = stringObject;
-    temp["logMetadata"] = "ABC123";
-    logger.warn("writing warn level:", temp);*/
+    let correlationVector = "ABC123"
+    logger.info("Logging at default level with logMetadata:", correlationVector);
+    logger.warn("Logging at  warn level with logMetadata & logObject:", correlationVector, stringObject);
+    logger.warn("Logging at  warn level without logObject:", correlationVector);
 });
 
 test("Logger with default parameters can add and remove transports", async t => {

--- a/node/test/OpenT2TTests.ts
+++ b/node/test/OpenT2TTests.ts
@@ -150,8 +150,9 @@ test("Logger can be instantiated with custom file parameter", async t => {
 
 test("Logger with default parameters can log custom loggingMetadata parameter like a correlationVector", async t => {
     let logger = new Logger();
-    logger.info("Writing default level to default console with loggingMetadata: ", undefined, "ABC123");
-    logger.warn("writing warn level to default console with loggingMetadata.", undefined, "XYZ456");
+    let stringObject = "Random String"
+    logger.info("Writing default level to default console with loggingMetadata:", stringObject, "ABC123");
+    logger.warn("writing warn level to default console with loggingMetadata:", undefined, "XYZ456");
 });
 
 test("Logger with default parameters can add and remove transports", async t => {

--- a/node/test/OpenT2TTests.ts
+++ b/node/test/OpenT2TTests.ts
@@ -130,7 +130,7 @@ test("Logger with default parameters can log a non-primitive type", async t => {
     let myArray: Array<any> = ["firstObject", "secondObject", ["nestedObj1", "nestedObj2"]];
     logger.info("Writing default level to default console.");
     logger.debug("writing debug level to default console.");
-    logger.warn("Writing array object to default console", myArray);
+    logger.error("Writing array object to default console", myArray);
 });
 
 test("Logger with default parameters can be instantiated multiple times", async t => {
@@ -148,11 +148,27 @@ test("Logger can be instantiated with custom file parameter", async t => {
     t.is(logger.getConfiguredTransports().length, 2);
 });
 
-test("Logger with default parameters can log custom loggingMetadata parameter like a correlationVector", async t => {
+test("Logger can log custom logMetadata, e.g. correlationVector", async t => {
     let logger = new Logger();
     let stringObject = "Random String"
-    logger.info("Writing default level to default console with loggingMetadata:", stringObject, "ABC123");
-    logger.warn("writing warn level to default console with loggingMetadata:", undefined, "XYZ456");
+    logger.info("Logging at default level with logMetadata:", stringObject, "ABC123");
+
+    // Swapping order of logObject and logMetadata since the latter will be used more often
+    // Pro: Simple usage
+    logger.warn("Logging at  warn level with logMetadata & logObject:", "ABC123", stringObject);
+    logger.warn("Logging at  warn level without logObject:", "ABC123");
+
+    // Map: Usage gets complicated
+/*    var temp = new Map<any, string>();
+    temp.set('logObject', stringObject);
+    temp.set('logMetadata', "ABC123");
+    logger.warn("writing warn level:", temp);*/
+    
+    // Associative Array: Usage still complicated, and winston doesn't log the Array contents, though console.log does
+/*    var temp:any = new Array();
+    temp["logObject"] = stringObject;
+    temp["logMetadata"] = "ABC123";
+    logger.warn("writing warn level:", temp);*/
 });
 
 test("Logger with default parameters can add and remove transports", async t => {


### PR DESCRIPTION
Tested with translator (adhoc changes, not sending out PR) as well newly added unit tests. npm run lint shows some issues but most of them are unrelated to this PR. 

Since we now have 2 optional parameters, "undefined" is logged for the 2nd field (logObject), in case there is a 3rd field (loggingMetadata) in each of the logging statements. As an example I updated the warn method to avoid logging undefined, but I am not sure if we want to avoid logging it, or if we do, if there is a better solution?
